### PR TITLE
More configuration parsing tests

### DIFF
--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -13,6 +13,7 @@ where
 import BasePrelude
 
 import Control.Concurrent.STM (atomically)
+import qualified Data.List.NonEmpty as NE
 import Named ((:!), arg)
 import System.Directory (listDirectory, doesFileExist)
 import System.FilePath ((</>), takeExtension, takeFileName)
@@ -94,7 +95,7 @@ reloadRules logger settings appState = do
     atomically $
         setRules appState
             [ ( domainDefinitionId rule
-              , definitionsToRuleTree (domainDefinitionDescriptors rule))
+              , definitionsToRuleTree (NE.toList . domainDefinitionDescriptors $ rule))
             | rule <- ruleDefinitions
             ]
     Logger.info logger $

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -151,6 +151,8 @@ data DescriptorDefinition = DescriptorDefinition
 instance FromJSON DomainDefinition where
     parseJSON = withObject "DomainDefinition" $ \o -> do
         domainDefinitionId <- o .: "domain"
+        when (domainDefinitionId == DomainId "") $
+          fail "rate limit domain must not be empty"
         domainDefinitionDescriptors <- o .: "descriptors"
         pure DomainDefinition{..}
 

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -37,6 +37,8 @@ import Data.Hashable (Hashable)
 import Data.Text (Text)
 import Data.Aeson (FromJSON(..), (.:), (.:?), withObject, withText)
 import Data.HashMap.Strict (HashMap)
+import qualified Data.List.NonEmpty as NE
+
 
 ----------------------------------------------------------------------------
 -- Time units
@@ -133,7 +135,7 @@ instance FromJSON RateLimit where
 -- Corresponds to one YAML file.
 data DomainDefinition = DomainDefinition
     { domainDefinitionId :: !DomainId
-    , domainDefinitionDescriptors :: ![DescriptorDefinition]
+    , domainDefinitionDescriptors :: !(NE.NonEmpty DescriptorDefinition)
     }
     deriving stock (Eq, Show)
 


### PR DESCRIPTION
This pull requests adds more configuration parsing tests. It also updates the parsing logic by adding checks that the domain id cannot be empty and that the descriptor list cannot be empty.

Closes #21.
Closes #22.
Closes #23.