### PR TITLE
Better secret management for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,15 +62,15 @@ compile_integration:
 
 integration:
   stage: test
-  image: docker:19.03.0
+  image: docker:19.03.2
   variables:
     DOCKER_DRIVER: overlay2
     DOCKER_TLS_CERTDIR: "/certs"
   services:
-    - docker:19.03.0-dind
+    - docker:19.03.2-dind
   script:
     # Create a Docker network for the containers
-    - docker network create test
+    - docker network create test-net
 
     # Run Fencer
     - docker load -i fencer.tar.gz
@@ -79,7 +79,7 @@ integration:
         -e RUNTIME_SUBDIRECTORY=ratelimit
         -p 50051:50051
         --name fencer
-        --network test
+        --network test-net
         --detach
         juspay/fencer
     - sleep 5
@@ -88,5 +88,5 @@ integration:
     - docker load -i test_integration_go.tar.gz
     - docker run
         -e GRPC_HOST=fencer
-        --network test
+        --network test-net
         test_integration_go

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,13 @@ stages:
 ### Secret management
 
 # Don't allow reading secret-containing files so that we won't leak secrets
-# into build outputs. We also use files instead of environment variables to
-# pass secrets - otherwise the trick would not work.
+# into build outputs.
+#
+# We use files instead of environment variables to pass secrets - otherwise
+# the trick would not work.
+#
+# NOTE: other jobs may not use "before_script" because it will override the
+# "before_script" we define here.
 default:
   before_script:
     # All SECRET_* variables point to files containing secrets; make them
@@ -63,8 +68,6 @@ integration:
     DOCKER_TLS_CERTDIR: "/certs"
   services:
     - docker:19.03.0-dind
-  before_script:
-    - docker info
   script:
     # Create a Docker network for the containers
     - docker network create test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,28 @@ stages:
   - build
   - test
 
+### Secret management
+
+# Don't allow reading secret-containing files so that we won't leak secrets
+# into build outputs. We also use files instead of environment variables to
+# pass secrets - otherwise the trick would not work.
+default:
+  before_script:
+    # All SECRET_* variables point to files containing secrets; make them
+    # unreadable.
+    - for var in $(env | awk -F= '{if($1 ~ /SECRET_/) print $1}'); do
+        ( eval filename=\$$var;
+          chmod 0 $filename; )
+      done
+
+    # get_secret loads secret X from the SECRET_X file.
+    - get_secret() {
+        eval local filename=\$SECRET_$1;
+        chmod 400 $filename;
+        export $1="$(cat $filename)";
+        chmod 0 $filename;
+      }
+
 ### Build
 
 # Build the Fencer Docker image
@@ -13,7 +35,8 @@ compile:
     - cachix use fencer
     - imagepath=$(nix-build docker.nix)
     - nix-store -qR --include-outputs $(nix-instantiate docker.nix)
-        | cachix push fencer
+        | ( get_secret CACHIX_SIGNING_KEY;
+            cachix push fencer )
     - cp $imagepath fencer.tar.gz
   artifacts:
     paths:


### PR DESCRIPTION
In GitLab CI, we define variables containing secrets, e.g. `CACHIX_SIGNING_KEY` for uploading build artifacts to Cachix.

Currently we risk leaking those secrets in build artifacts if a dependency decides to embed environment variables into its binary (for whatever reason). An extensive description of how it happens can be found here: https://secrethub.io/blog/decouple-application-secrets-from-ci-cd-pipeline/.

It does \*not\* happen with the current set of dependencies, but may happen with future dependencies.

To prevent this, we switch all environment variables to be stored in files:

![image](https://user-images.githubusercontent.com/1523306/66045969-6c9c9180-e52d-11e9-94bb-2112485e2eb2.png)

During the build, GitLab will set `SECRET_CACHIX_SIGNING_KEY` to contain a filepath to the key. We make it unreadable with `chmod 0`:

```yaml
    - for var in $(env | awk -F= '{if($1 ~ /SECRET_/) print $1}'); do
        ( eval filename=\$$var;
          chmod 0 $filename; )
      done
```

Then we define a function `get_secret` that will read the file and store its contents in `CACHIX_SIGNING_KEY`:

```yaml
    # get_secret loads secret X from the SECRET_X file.
    - get_secret() {
        eval local filename=\$SECRET_$1;
        chmod 400 $filename;
        export $1="$(cat $filename)";
        chmod 0 $filename;
      }
```

The use of a subshell ensures that the variable is only alive while the executable is ran. Example:

```yaml
    # CACHIX_SIGNING_KEY is not available here
    - nix-store -qR --include-outputs $(nix-instantiate docker.nix)
        | ( get_secret CACHIX_SIGNING_KEY;
             # available here
            cachix push fencer )
    # not available here again
```