### PR TITLE
Separate nix files into {default, shell, nixpkgs}.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,8 @@
-{
-  withHoogle ? true
+{ withHoogle ? false
 , static ? false
 }:
 let
-  inherit (import <nixpkgs> {}) fetchFromGitHub;
-  nixpkgs = fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "db858b4d3032aec35be7e98a65eb9b91b63671ef";
-    sha256 = "0gqcbf5nyqff1a4ps6szcrv59ay97fr26jdwrs7qp8fijzcpdnkh";
-  };
+  nixpkgs = import ./nixpkgs.nix;
   staticPackage = pkg: pkg.overrideAttrs (old: {
     enableSharedExecutables = false;
     enableSharedLibraries = false;
@@ -91,25 +84,10 @@ let
     if static
     then staticPackage pkgs.haskellPackages.fencer
     else pkgs.haskellPackages.fencer;
-in
-  if pkgs.lib.inNixShell
-    then
-      drv.env.overrideAttrs(attrs:
-        { buildInputs =
-          [
-            pkgs.haskellPackages.cabal-install
-            pkgs.haskellPackages.cabal2nix
-            pkgs.haskellPackages.ghcid
-            pkgs.haskellPackages.hlint
-          ] ++
-          [
-            pkgs.haskellPackages.zlib
-          ] ++
-          [
-            pkgs.wget
-          ] ++
-          attrs.buildInputs;
-        })
-    else
-      # https://github.com/Gabriel439/haskell-nix/blob/master/project3/README.md#minimizing-the-closure
-      pkgs.haskell.lib.justStaticExecutables drv
+in {
+  pkgs = pkgs;
+  fencer =
+    if pkgs.lib.inNixShell
+    then drv
+    else pkgs.haskell.lib.justStaticExecutables drv;
+}

--- a/docker.nix
+++ b/docker.nix
@@ -1,15 +1,8 @@
 let
-  inherit (import <nixpkgs> {}) fetchFromGitHub;
-  nixpkgs = fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "db858b4d3032aec35be7e98a65eb9b91b63671ef";
-    sha256 = "0gqcbf5nyqff1a4ps6szcrv59ay97fr26jdwrs7qp8fijzcpdnkh";
-  };
-  pkgs = import nixpkgs { };
   # TODO: this rebuilds 'fencer', can we avoid that?
-  fencer = import ./default.nix { };
-
+  drv = import ./default.nix { };
+  pkgs = drv.pkgs;
+  fencer = drv.fencer;
 in
 pkgs.dockerTools.buildImage {
   name = "juspay/fencer";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,6 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/db858b4d3032aec35be7e98a65eb9b91b63671ef";
+    sha256 = "0gqcbf5nyqff1a4ps6szcrv59ay97fr26jdwrs7qp8fijzcpdnkh";
+  };
+in nixpkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+let
+  drv = import ./default.nix { withHoogle = true; };
+  pkgs = drv.pkgs;
+in drv.fencer.env.overrideAttrs (attrs: {
+  buildInputs = [
+    pkgs.haskellPackages.cabal-install
+    pkgs.haskellPackages.cabal2nix
+    pkgs.haskellPackages.ghcid
+    pkgs.haskellPackages.hlint
+  ] ++ [
+    pkgs.haskellPackages.zlib
+  ] ++ [
+    pkgs.wget
+  ] ++ attrs.buildInputs;
+})


### PR DESCRIPTION
This helps in extending `default.nix` in any way we want to
- `nix-build` uses `default.nix`
- `nix-shell` uses `shell.nix`

So it's all separated and if need be, only update the files as required and if `nixpkgs`
version is to be changed then `nixpkgs.nix` it is

Fixes #39 