### PR TITLE
Use cleanSource to avoid including result/ in the source tree

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -71,7 +71,7 @@ let
               (self.callPackage ./nix/grpc-haskell.nix { });
 
           fencer =
-            self.callCabal2nix "fencer" (./.) { };
+            self.callCabal2nix "fencer" (pkgs.lib.cleanSource ./.) { };
         };
       };
     };

--- a/docker.nix
+++ b/docker.nix
@@ -1,5 +1,4 @@
 let
-  # TODO: this rebuilds 'fencer', can we avoid that?
   drv = import ./default.nix { };
   pkgs = drv.pkgs;
   fencer = drv.fencer;


### PR DESCRIPTION
Previously, doing `nix-build` and then `nix-build docker.nix` built Fencer twice. Now the second invocation is able to reuse Fencer built during the previous invocation.

Investigation log:

```diff
$ nix-diff \
    /nix/store/d45xgz246p96ffj5pa2dlyyj6z2y9a4v-fencer-1.0.0.drv \
    /nix/store/yszv7zaka2bck86i1ndl6dqadazr4i52-fencer-1.0.0.drv

- /nix/store/d45xgz246p96ffj5pa2dlyyj6z2y9a4v-fencer-1.0.0.drv:{out}
+ /nix/store/yszv7zaka2bck86i1ndl6dqadazr4i52-fencer-1.0.0.drv:{out}
• The set of input sources do not match:
    - /nix/store/07lbf82l6xh14ypz73jhzp36q0q9a2ag-fencer
    + /nix/store/d52lf9f6cpya9qann1dg0pdai6q743mz-fencer
```

```diff
$ git diff --no-index \
    /nix/store/07lbf82l6xh14ypz73jhzp36q0q9a2ag-fencer \
    /nix/store/d52lf9f6cpya9qann1dg0pdai6q743mz-fencer

diff --git a/nix/store/07lbf82l6xh14ypz73jhzp36q0q9a2ag-fencer/result b/nix/store/d52lf9f6cpya9qann1dg0pdai6q743mz-fencer/result
index 875adc4..c1f8bfe 120000
--- a/nix/store/07lbf82l6xh14ypz73jhzp36q0q9a2ag-fencer/result
+++ b/nix/store/d52lf9f6cpya9qann1dg0pdai6q743mz-fencer/result
@@ -1 +1 @@
-/nix/store/x79b9ngd6cvfpmr3yg98d4a08f0kspka-docker-image-fencer.tar.gz
\ No newline at end of file
+/nix/store/xnp82zr60q49dd9i7zhc37fkzf2jib7j-fencer-1.0.0
\ No newline at end of file
```