### PR TITLE
More faithful replication of lyft/ratelimit config loading rules: part 1

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -57,6 +57,7 @@ library
   build-depends:
     base,
     base-prelude,
+    extra,
     hashable,
     monad-loops,
     time,
@@ -119,6 +120,7 @@ test-suite test-fencer
     , aeson-qq
     , base
     , base-prelude
+    , directory
     , grpc-haskell
     , filepath
     , neat-interpolation

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -110,6 +110,7 @@ test-suite test-fencer
     test
   other-modules:
     Fencer.Types.Test
+    Fencer.Rules.Test
     Fencer.Server.Test
   default-language:
     Haskell2010
@@ -119,11 +120,14 @@ test-suite test-fencer
     , base
     , base-prelude
     , grpc-haskell
+    , filepath
+    , neat-interpolation
     , proto3-wire
     , proto3-suite
     , tasty
     , tasty-discover
     , tasty-hunit
+    , temporary
     , text
     , tinylog
     , unordered-containers

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -15,7 +15,7 @@ import BasePrelude
 import qualified Data.HashMap.Strict as HM
 import Named ((:!), arg)
 import System.Directory (listDirectory, doesFileExist)
-import System.FilePath ((</>), takeExtension, takeFileName)
+import System.FilePath ((</>), takeFileName)
 import qualified Data.Yaml as Yaml
 
 import Fencer.Types
@@ -36,15 +36,11 @@ loadRulesFromDirectory
     files <-
         filterM doesFileExist . map (directory </>) =<<
         listDirectory directory
-    let ruleFiles =
-            (if ignoreDotFiles then filter (not . isDotFile) else id) $
-            filter isYaml files
-    mapM Yaml.decodeFileThrow ruleFiles
-    -- TODO: what does lyft/ratelimit do with unparseable files?
+    mapM Yaml.decodeFileThrow $
+        if ignoreDotFiles
+            then filter (not . isDotFile) files
+            else files
   where
-    isYaml :: FilePath -> Bool
-    isYaml file = takeExtension file `elem` [".yml", ".yaml"]
-
     isDotFile :: FilePath -> Bool
     isDotFile file = "." `isPrefixOf` takeFileName file
 

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -12,16 +12,17 @@ where
 
 import BasePrelude
 
+import Control.Monad.Extra (partitionM, concatMapM)
 import qualified Data.HashMap.Strict as HM
 import Named ((:!), arg)
-import System.Directory (listDirectory, doesFileExist)
+import System.Directory (listDirectory, doesFileExist, doesDirectoryExist, pathIsSymbolicLink)
 import System.FilePath ((</>), takeFileName)
 import qualified Data.Yaml as Yaml
 
 import Fencer.Types
 
--- | Gather rate limiting rules (*.yml, *.yaml) from a directory.
--- Subdirectories are not included.
+-- | Read rate limiting rules from a directory, recursively. Files are
+-- assumed to be YAML, but do not have to have a @.yml@ extension.
 --
 -- Throws an exception for unparseable or unreadable files.
 loadRulesFromDirectory
@@ -33,9 +34,7 @@ loadRulesFromDirectory
     (arg #ignoreDotFiles -> ignoreDotFiles)
     =
     do
-    files <-
-        filterM doesFileExist . map (directory </>) =<<
-        listDirectory directory
+    files <- listAllFiles directory
     mapM Yaml.decodeFileThrow $
         if ignoreDotFiles
             then filter (not . isDotFile) files
@@ -43,6 +42,27 @@ loadRulesFromDirectory
   where
     isDotFile :: FilePath -> Bool
     isDotFile file = "." `isPrefixOf` takeFileName file
+
+    -- | Is the path a true directory (not a symlink)?
+    isDirectory :: FilePath -> IO Bool
+    isDirectory dir =
+        liftA2 (&&)
+            (doesDirectoryExist dir)
+            (not <$> (pathIsSymbolicLink dir `catchIOError` \_ -> pure False))
+
+    -- | List all files in a directory, recursively, without following
+    -- symlinks.
+    listAllFiles :: FilePath -> IO [FilePath]
+    listAllFiles dir = do
+        -- TODO: log exceptions
+        contents <-
+            map (dir </>) <$>
+            (listDirectory dir `catchIOError` \_ -> pure [])
+        -- files = normal files and links to files
+        -- dirs = directories, but not links to directories
+        (files, other) <- partitionM doesFileExist contents
+        dirs <- filterM isDirectory other
+        (files ++) <$> concatMapM listAllFiles dirs
 
 -- | Convert a list of descriptors to a 'RuleTree'.
 definitionsToRuleTree :: [DescriptorDefinition] -> RuleTree

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -85,7 +85,7 @@ timeUnitToSeconds = \case
 
 -- | Domain name. Several rate limiting rules can belong to the same domain.
 newtype DomainId = DomainId Text
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Ord, Show)
     deriving newtype (Hashable, FromJSON)
 
 -- | Unwrap 'DomainId'.

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLabels  #-}
+
+-- | Tests for "Fencer.Rules".
+module Fencer.Rules.Test
+  ( test_loadRulesYaml
+  )
+where
+
+import           BasePrelude
+
+import           Data.Text (Text)
+import qualified Data.Text.IO as TIO
+import           Test.Tasty (TestTree)
+import           Test.Tasty.HUnit (assertEqual, testCase)
+import qualified System.IO.Temp as Temp
+import           NeatInterpolation (text)
+import           System.FilePath ((</>))
+import           Data.List (sortOn)
+
+import           Fencer.Types
+import           Fencer.Rules
+
+-- | Test that 'loadRulesFromDirectory' loads rules from YAML files.
+test_loadRulesYaml :: TestTree
+test_loadRulesYaml =
+  testCase "Rules are loaded from YAML files" $ do
+    Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
+      TIO.writeFile (tempDir </> "config1.yml") domain1Text
+      TIO.writeFile (tempDir </> "config2.yaml") domain2Text
+      definitions <-
+        loadRulesFromDirectory (#directory tempDir) (#ignoreDotFiles True)
+      assertEqual "unexpected definitions"
+        (sortOn domainDefinitionId [domain1, domain2])
+        (sortOn domainDefinitionId definitions)
+
+----------------------------------------------------------------------------
+-- Sample definitions
+----------------------------------------------------------------------------
+
+domain1 :: DomainDefinition
+domain1 = DomainDefinition
+  { domainDefinitionId = DomainId "domain1"
+  , domainDefinitionDescriptors = descriptor1 :| []
+  }
+  where
+    descriptor1 :: DescriptorDefinition
+    descriptor1 = DescriptorDefinition
+      { descriptorDefinitionKey = RuleKey "some key"
+      , descriptorDefinitionValue = Just $ RuleValue "some value"
+      , descriptorDefinitionRateLimit = Nothing
+      , descriptorDefinitionDescriptors = Nothing
+      }
+
+domain1Text :: Text
+domain1Text = [text|
+  domain: domain1
+  descriptors:
+    - key: some key
+      value: some value
+  |]
+
+domain2 :: DomainDefinition
+domain2 = DomainDefinition
+  { domainDefinitionId = DomainId "domain2"
+  , domainDefinitionDescriptors = descriptor2 :| []
+  }
+  where
+    descriptor2 :: DescriptorDefinition
+    descriptor2 = DescriptorDefinition
+      { descriptorDefinitionKey = RuleKey "some key 2"
+      , descriptorDefinitionValue = Nothing
+      , descriptorDefinitionRateLimit = Nothing
+      , descriptorDefinitionDescriptors = Nothing
+      }
+
+domain2Text :: Text
+domain2Text = [text|
+  domain: domain2
+  descriptors:
+    - key: some key 2
+  |]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,1 +1,1 @@
-{-# OPTIONS_GHC -F -pgmF tasty-discover #-}
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display #-}


### PR DESCRIPTION
* Rules are loaded recursively.
* Rules are loaded from files without the `.yml` extension.

Related to #26.