### PR TITLE
Fix docker image created time to current time

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -6,6 +6,7 @@ in
 pkgs.dockerTools.buildImage {
   name = "juspay/fencer";
   tag = "latest";
+  created = "now";
   contents = fencer;
   config.Cmd = [ "${fencer}/bin/fencer" ];
 }


### PR DESCRIPTION
If the option is not specified, it defaults to EPOCH time

```bash
$ docker inspect -f '{{ .Created }}' juspay/fencer
2019-10-05T04:54:00Z
```

Fixes #48 