### PR TITLE
Replicate counter identity rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,17 @@ you shouldn’t have made this request because you are over the limit".
 
 ### Rate limiting models
 
-There are two models for rate limiting – the "bucket" one and the "rolling
-window" one. In the bucket model you have a single counter which is as
-granular as the rate-limiting unit – say, if the limit is "N requests per
-hour" then the counter will get incremented for all requests for
-X:00:00–X:59:59. If you have spent your limit at the beginning of the hour,
-you don't get any credit until the next hour starts and the counter resets.
+There are two models for rate limiting – the "bucket" one and the
+"rolling window" one. In the bucket model you have a single counter
+which is as granular as the rate-limiting unit – say, if the limit is
+"N requests per hour" then the counter will get incremented for all
+requests for X:00:00–X:59:59. If you have spent your limit at the
+beginning of the hour, you don't get any credit until the next hour
+starts and the counter resets. Every counter is indexed by a time unit
+so that if there is an update in the configuration and rules are
+reloaded as a result, a change in time limit yields a new reset
+counter; if there is an update in the request rate only, an existing
+counter is updated.
 
 The "rolling window" model is more interesting. In this model, you are
 limited based on how many requests you’ve made in the past hour, which

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -106,7 +106,7 @@ test-suite test-fencer
   type:
     exitcode-stdio-1.0
   main-is:
-    Tests.hs
+    Main.hs
   hs-source-dirs:
     test
   other-modules:
@@ -128,7 +128,6 @@ test-suite test-fencer
     , proto3-suite
     , stm-containers
     , tasty
-    , tasty-discover
     , tasty-hunit
     , temporary
     , text

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -126,6 +126,7 @@ test-suite test-fencer
     , neat-interpolation
     , proto3-wire
     , proto3-suite
+    , stm-containers
     , tasty
     , tasty-discover
     , tasty-hunit

--- a/lib/Fencer/AppState.hs
+++ b/lib/Fencer/AppState.hs
@@ -5,6 +5,8 @@
 -- | In-memory state of Fencer.
 module Fencer.AppState
     ( AppState
+    , appStateCounters
+    , appStateRules
     , initAppState
 
     -- * Methods for working with 'AppState'
@@ -27,10 +29,10 @@ import Named ((:!), arg)
 import qualified Focus as Focus
 import Control.Monad.Trans.Class (lift)
 
-import Fencer.Types
 import Fencer.Counter
-import Fencer.Time
 import Fencer.Rules
+import Fencer.Time
+import Fencer.Types
 
 -- | Fencer runtime context and in-memory state.
 --
@@ -158,7 +160,7 @@ getLimit appState domain descriptor =
 -- The 'appStateCounters' field stays unchanged. This is in accordance
 -- with the behavior of @lyft/ratelimit@.
 --
--- There might be a change in rulsets with the same descriptors that
+-- There might be a change in rules with the same descriptors that
 -- updates the value of 'requests_per_unit' (with the time unit left
 -- intact), which allows a different number of requests to be
 -- made. This is as expected. However, if there is a change in the

--- a/lib/Fencer/AppState.hs
+++ b/lib/Fencer/AppState.hs
@@ -154,6 +154,16 @@ getLimit appState domain descriptor =
         Just ruleTree -> pure (applyRules descriptor ruleTree)
 
 -- | Set 'appStateRules' and 'appStateRulesLoaded'.
+--
+-- The 'appStateCounters' field stays unchanged. This is in accordance
+-- with the behavior of @lyft/ratelimit@.
+--
+-- There might be a change in rulsets with the same descriptors that
+-- updates the value of 'requests_per_unit' (with the time unit left
+-- intact), which allows a different number of requests to be
+-- made. This is as expected. However, if there is a change in the
+-- rate limit time unit, a new counter will be created, regardless of
+-- how many requests the previous counter had used up.
 setRules :: AppState -> [(DomainId, RuleTree)] -> STM ()
 setRules appState rules = do
     writeTVar (appStateRulesLoaded appState) True

--- a/lib/Fencer/Counter.hs
+++ b/lib/Fencer/Counter.hs
@@ -36,7 +36,7 @@ data Counter = Counter
       -- | Counter expiry date, inclusive (i.e. on 'counterExpiry' the
       -- counter is already expired).
     , counterExpiry :: !Timestamp
-    }
+    } deriving Eq
 
 data CounterStatus = CounterStatus
     { -- | How many hits can be taken before the limit is reached. Will be 0

--- a/lib/Fencer/Counter.hs
+++ b/lib/Fencer/Counter.hs
@@ -24,6 +24,7 @@ import Fencer.Time
 data CounterKey = CounterKey
     { counterKeyDomain :: !DomainId
     , counterKeyDescriptor :: ![(RuleKey, RuleValue)]
+    , counterKeyUnit :: !TimeUnit
     }
     deriving stock (Eq, Generic)
     deriving anyclass (Hashable)

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -89,7 +89,11 @@ reloadRules logger settings appState = do
                     show (map (unDomainId . domainDefinitionId) ruleDefinitions))
 
     -- Recreate 'appStateRules'
+    --
+    -- There is no need to remove old rate limiting rules
     atomically $
+        -- See the documentation of 'setRules' for details on what
+        -- happens with counters during rule reloading.
         setRules appState
             [ ( domainDefinitionId rule
               , definitionsToRuleTree (NE.toList . domainDefinitionDescriptors $ rule))

--- a/lib/Fencer/Server.hs
+++ b/lib/Fencer/Server.hs
@@ -136,13 +136,13 @@ shouldRateLimitDescriptor appState (arg #hits -> hits) domain descriptor =
     getLimit appState domain descriptor >>= \case
         Nothing -> pure Nothing
         Just limit -> do
+            let counterKey :: CounterKey
+                counterKey = CounterKey
+                  { counterKeyDomain = domain
+                  , counterKeyDescriptor = descriptor
+                  , counterKeyUnit = rateLimitUnit limit }
             status <- recordHits appState (#hits hits) (#limit limit) counterKey
             pure (Just (limit, status))
-  where
-    counterKey :: CounterKey
-    counterKey = CounterKey
-        { counterKeyDomain = domain
-        , counterKeyDescriptor = descriptor }
 
 ----------------------------------------------------------------------------
 -- Working with protobuf structures

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -16,7 +16,7 @@ import           BasePrelude
 import qualified Data.HashMap.Strict as HM
 import           Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (fromJust)
+import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text.IO as TIO
 import           NeatInterpolation (text)
@@ -95,9 +95,10 @@ test_rulesLimitUnitChange =
 
         atomically $ setRules state (mapRuleDefs definitions1)
 
-        ruleTree :: RuleTree <- atomically $ fromJust <$> StmMap.lookup domainId (appStateRules state)
-        let ruleBranch :: RuleBranch = fromJust $ HM.lookup (ruleKey, Just ruleValue) ruleTree
-        let rateLimit = fromJust $ ruleBranchRateLimit ruleBranch
+        ruleTree :: RuleTree <- atomically $
+          fromMaybe' <$> StmMap.lookup domainId (appStateRules state)
+        let ruleBranch = fromMaybe' $ HM.lookup (ruleKey, Just ruleValue) ruleTree
+        let rateLimit =  fromMaybe' $ ruleBranchRateLimit ruleBranch
 
         -- Record a hit
         void $ atomically $ recordHits state (#hits 1) (#limit rateLimit) counterKey1
@@ -147,6 +148,9 @@ test_rulesLimitUnitChange =
 
   counterKey2 :: CounterKey
   counterKey2 = counterKey1 { counterKeyUnit = Hour }
+
+  fromMaybe' :: Maybe a -> a
+  fromMaybe' = fromMaybe (error "")
 
 
 ----------------------------------------------------------------------------

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -4,10 +4,10 @@
 
 -- | Tests for "Fencer.Rules".
 module Fencer.Rules.Test
-  ( test_loadRulesYaml
-  , test_loadRulesNonYaml
-  , test_loadRulesRecursively
-  , test_ruleLimitUnitChange
+  ( test_rulesLoadRulesYaml
+  , test_rulesLoadRulesNonYaml
+  , test_rulesLoadRulesRecursively
+  , test_rulesLimitUnitChange
   )
 where
 
@@ -36,8 +36,8 @@ import           Fencer.Server.Test (createServerAppState, destroyServerAppState
 
 
 -- | Test that 'loadRulesFromDirectory' loads rules from YAML files.
-test_loadRulesYaml :: TestTree
-test_loadRulesYaml =
+test_rulesLoadRulesYaml :: TestTree
+test_rulesLoadRulesYaml =
   testCase "Rules are loaded from YAML files" $ do
     Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
       TIO.writeFile (tempDir </> "config1.yml") domain1Text
@@ -52,8 +52,8 @@ test_loadRulesYaml =
 -- YAML files.
 --
 -- This counterintuitive behavior matches the behavior of @lyft/ratelimit@.
-test_loadRulesNonYaml :: TestTree
-test_loadRulesNonYaml =
+test_rulesLoadRulesNonYaml :: TestTree
+test_rulesLoadRulesNonYaml =
   testCase "Rules are loaded from non-YAML files" $ do
     Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
       TIO.writeFile (tempDir </> "config1.bin") domain1Text
@@ -67,8 +67,8 @@ test_loadRulesNonYaml =
 -- | Test that 'loadRulesFromDirectory' loads rules recursively.
 --
 -- This matches the behavior of @lyft/ratelimit@.
-test_loadRulesRecursively :: TestTree
-test_loadRulesRecursively =
+test_rulesLoadRulesRecursively :: TestTree
+test_rulesLoadRulesRecursively =
   testCase "Rules are loaded recursively" $ do
     Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
       createDirectoryIfMissing True (tempDir </> "domain1")
@@ -83,21 +83,8 @@ test_loadRulesRecursively =
 
 -- | Test that a rule limit unit change adds a new counter and leaves
 -- the old one intact.
---
--- TODO(md)-2019-10-11: Sometimes this test non-deterministically fails with:
---
--- Got wrong gRPC error response
---         expected: ClientIOError (GRPCIOBadStatusCode StatusUnknown
---           (StatusDetails {unStatusDetails = "rate limit descriptor
---             list must not be empty"}))
---          but got: ClientIOError (GRPCIOBadStatusCode StatusUnavailable
---            (StatusDetails {unStatusDetails = "Endpoint read failed"}))
-test_ruleLimitUnitChange :: TestTree
-test_ruleLimitUnitChange =
-  -- TODO(md): creating a server here sometimes clashes with executing
-  -- server tests concurrently, which occasionally leads to test
-  -- failures. Fix this either by making sure the port hasn't been
-  -- binded or in some other way.
+test_rulesLimitUnitChange :: TestTree
+test_rulesLimitUnitChange =
   withResource createServerAppState destroyServerAppState $ \ioLogIdState ->
     testCase "A rule limit unit change on rule reloading" $ do
       Temp.withSystemTempDirectory "fencer-config-unit" $ \tempDir -> do

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -5,7 +5,7 @@
 
 -- | Tests for "Fencer.Server".
 module Fencer.Server.Test
-  ( test_responseNoRules
+  ( test_serverResponseNoRules
   , createServerAppState
   , destroyServerAppState
   )
@@ -30,8 +30,8 @@ import qualified Fencer.Proto as Proto
 -- 'reloadRules' has never been ran), requests to Fencer will error out.
 --
 -- This behavior matches @lyft/ratelimit@.
-test_responseNoRules :: TestTree
-test_responseNoRules =
+test_serverResponseNoRules :: TestTree
+test_serverResponseNoRules =
   withResource createServer destroyServer $ \_ ->
     testCase "When no rules have been loaded, all requests error out" $ do
       Grpc.withGRPCClient clientConfig $ \grpcClient -> do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,41 @@
+module Main where
+
+import           Test.Tasty (after, defaultMain, testGroup, DependencyType(AllFinish), TestTree)
+
+import           BasePrelude
+
+import qualified Fencer.Rules.Test as R
+import qualified Fencer.Server.Test as S
+import qualified Fencer.Types.Test as T
+
+
+tests :: TestTree
+tests = testGroup "All tests"
+  [ types
+  , rules
+  , after AllFinish "test_rules" server
+  ]
+
+server :: TestTree
+server = testGroup "Server tests" [S.test_serverResponseNoRules]
+
+rules :: TestTree
+rules = testGroup "Rule tests"
+  [ R.test_rulesLoadRulesYaml
+  , R.test_rulesLoadRulesNonYaml
+  , R.test_rulesLoadRulesRecursively
+  , R.test_rulesLimitUnitChange
+  ]
+
+types :: TestTree
+types = testGroup "Type tests"
+  [ T.test_parseJSONDescriptorDefinition
+  , T.test_parseJSONDomainDefinition
+  , T.test_parseJSONDomainAtLeastOneDescriptor
+  , T.test_parseJSONNonEmptyDomainId
+  , T.test_parseJSONOptionalDescriptorFields
+  ]
+
+
+main :: IO ()
+main = defaultMain tests

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,6 +13,11 @@ tests :: TestTree
 tests = testGroup "All tests"
   [ types
   , rules
+  -- 'after' is needed to avoid running the 'rules' and 'server' tests
+  -- concurrently. Running them concurrently is problematic because
+  -- both create a server (binding the same port) so if they create it
+  -- at the same time, one of the test groups will fail. The 'after'
+  -- function makes 'server' tests run after 'rules' tests.
   , after AllFinish "test_rules" server
   ]
 

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display #-}


### PR DESCRIPTION
This patch closes #13. It introduces a time unit to `CounterKey` to differentiate rules that are the same in everything but the time unit. If the time unit stays the same, but the rate limit changes, `fencer` does the same as `lyft/ratelimit`.