### PR TITLE
Allow configuring the gRPC server port

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ integration:
     - docker info
   script:
     # Create a Docker network for the containers
-    - docker network create test
+    - docker network inspect test >/dev/null 2>&1 || docker network create test
 
     # Run Fencer
     - docker load -i fencer.tar.gz

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Fencer-specific environment variables are:
   with names starting with a dot (hidden files on Linux-based systems
   and macOS). It can be `True` or `False`. The default value is
   `False`.
+- `GRPC_PORT` - The port to run the gRPC server on. Default is 50051.
 
 ## Developing
 

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -62,7 +62,7 @@ main = do
             -- TODO: clarify the counter removal logic?
             mapM_ (deleteCountersWithExpiry appState) [before .. pred now]
     -- Start the gRPC server
-    runServer logger appState
+    runServerWithPort (settingsGRPCPort settings) logger appState
 
 ----------------------------------------------------------------------------
 -- Load rules

--- a/lib/Fencer/Server.hs
+++ b/lib/Fencer/Server.hs
@@ -6,6 +6,7 @@
 -- | The gRPC server definition.
 module Fencer.Server
     ( runServer
+    , runServerWithPort
     )
 where
 
@@ -33,18 +34,24 @@ import qualified Fencer.Proto as Proto
 -- | Run the gRPC server serving ratelimit requests.
 --
 -- TODO: fail if the port is taken? or does it fail already?
-runServer :: Logger -> AppState -> IO ()
-runServer logger appState = do
+runServerWithPort :: Port -> Logger -> AppState -> IO ()
+runServerWithPort (Port port) logger appState = do
     let handlers = Proto.RateLimitService
             { Proto.rateLimitServiceShouldRateLimit = shouldRateLimit logger appState
             }
     let options = Grpc.defaultServiceOptions
             { Grpc.serverHost = "0.0.0.0"
+            , Grpc.serverPort = fromIntegral port
               -- TODO: set the logger
             }
     Logger.info logger $
         Logger.msg (Logger.val "Starting gRPC server at 0.0.0.0:50051")
     Proto.rateLimitServiceServer handlers options
+
+-- | Run the gRPC server serving ratelimit requests on the default
+-- 50051 port.
+runServer :: Logger -> AppState -> IO ()
+runServer = runServerWithPort (Port 50051)
 
 ----------------------------------------------------------------------------
 -- The "should rate limit" method

--- a/lib/Fencer/Server.hs
+++ b/lib/Fencer/Server.hs
@@ -22,10 +22,11 @@ import qualified Proto3.Suite.Types as ProtoSuite
 import qualified System.Logger as Logger
 import System.Logger (Logger)
 
-import Fencer.Types
-import Fencer.AppState
-import Fencer.Counter
+import           Fencer.AppState
+import           Fencer.Counter
 import qualified Fencer.Proto as Proto
+import           Fencer.Settings (defaultGRPCPort)
+import           Fencer.Types
 
 ----------------------------------------------------------------------------
 -- Server
@@ -51,7 +52,7 @@ runServerWithPort (Port port) logger appState = do
 -- | Run the gRPC server serving ratelimit requests on the default
 -- 50051 port.
 runServer :: Logger -> AppState -> IO ()
-runServer = runServerWithPort (Port 50051)
+runServer = runServerWithPort defaultGRPCPort
 
 ----------------------------------------------------------------------------
 -- The "should rate limit" method

--- a/lib/Fencer/Server.hs
+++ b/lib/Fencer/Server.hs
@@ -10,17 +10,19 @@ module Fencer.Server
     )
 where
 
-import BasePrelude
+import BasePrelude hiding ((+++))
 
-import Control.Concurrent.STM (atomically)
-import Named ((:!), arg)
-import Data.Text (Text)
+import           Control.Concurrent.STM (atomically)
+import           Named ((:!), arg)
+import qualified Data.ByteString.Char8 as B
+import           Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Vector as V
 import qualified Network.GRPC.HighLevel.Generated as Grpc
 import qualified Proto3.Suite.Types as ProtoSuite
 import qualified System.Logger as Logger
-import System.Logger (Logger)
+import           System.Logger (Logger)
+import           System.Logger.Message ((+++))
 
 import           Fencer.AppState
 import           Fencer.Counter
@@ -46,11 +48,11 @@ runServerWithPort (Port port) logger appState = do
               -- TODO: set the logger
             }
     Logger.info logger $
-        Logger.msg (Logger.val "Starting gRPC server at 0.0.0.0:50051")
+        Logger.msg (("Starting gRPC server at 0.0.0.0:" :: B.ByteString) +++ port)
     Proto.rateLimitServiceServer handlers options
 
 -- | Run the gRPC server serving ratelimit requests on the default
--- 50051 port.
+-- port.
 runServer :: Logger -> AppState -> IO ()
 runServer = runServerWithPort defaultGRPCPort
 

--- a/lib/Fencer/Settings.hs
+++ b/lib/Fencer/Settings.hs
@@ -32,7 +32,7 @@ data Settings = Settings
       -- value is @false@.
     , settingsIgnoreDotFiles :: Bool
       -- | @GRPC_PORT@: gRPC port to run the server on. The default
-      -- value is 50051.
+      -- value is 'defaultGRPCPort'.
     , settingsGRPCPort :: Port
     }
     deriving (Show)

--- a/lib/Fencer/Settings.hs
+++ b/lib/Fencer/Settings.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Fencer start-time config.
 module Fencer.Settings
@@ -8,6 +9,11 @@ module Fencer.Settings
 where
 
 import BasePrelude
+
+import Text.Read (readMaybe)
+
+import Fencer.Types (Port(..))
+
 
 -- | Fencer settings.
 data Settings = Settings
@@ -21,6 +27,9 @@ data Settings = Settings
       -- starting with a dot (hidden files on Linux and macOS). The default
       -- value is @false@.
     , settingsIgnoreDotFiles :: Bool
+      -- | @GRPC_PORT@: gRPC port to run the server on. The default
+      -- value is 50051.
+    , settingsGRPCPort :: Port
     }
     deriving (Show)
 
@@ -35,6 +44,11 @@ getSettingsFromEnvironment = do
         Just s -> case parseBool s of
             Just b -> pure b
             Nothing -> error ("Could not parse RUNTIME_IGNOREDOTFILES: " ++ show s)
+    settingsGRPCPort <- lookupEnv "GRPC_PORT" >>= \case
+        Nothing -> pure $ Port 50051
+        Just s  -> case readMaybe @Word s of
+            Nothing -> error ("Could not parse GRPC_PORT: " ++ show s)
+            Just p  -> pure $ Port p
     pure Settings{..}
 
 ----------------------------------------------------------------------------

--- a/lib/Fencer/Settings.hs
+++ b/lib/Fencer/Settings.hs
@@ -5,6 +5,7 @@
 module Fencer.Settings
     ( Settings(..)
     , getSettingsFromEnvironment
+    , defaultGRPCPort
     )
 where
 
@@ -14,6 +15,9 @@ import Text.Read (readMaybe)
 
 import Fencer.Types (Port(..))
 
+-- | The default port for a gRPC server
+defaultGRPCPort :: Port
+defaultGRPCPort = Port 50051
 
 -- | Fencer settings.
 data Settings = Settings
@@ -45,7 +49,7 @@ getSettingsFromEnvironment = do
             Just b -> pure b
             Nothing -> error ("Could not parse RUNTIME_IGNOREDOTFILES: " ++ show s)
     settingsGRPCPort <- lookupEnv "GRPC_PORT" >>= \case
-        Nothing -> pure $ Port 50051
+        Nothing -> pure defaultGRPCPort
         Just s  -> case readMaybe @Word s of
             Nothing -> error ("Could not parse GRPC_PORT: " ++ show s)
             Just p  -> pure $ Port p

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -28,6 +28,9 @@ module Fencer.Types
     -- * Rate limit rules in tree form
     , RuleTree
     , RuleBranch(..)
+
+    -- * Server
+    , Port(..)
     )
 where
 
@@ -179,3 +182,10 @@ data RuleBranch = RuleBranch
     { ruleBranchRateLimit :: !(Maybe RateLimit)
     , ruleBranchNested :: !RuleTree
     }
+
+----------------------------------------------------------------------------
+-- Fencer server
+----------------------------------------------------------------------------
+
+-- | A network port wrapper
+newtype Port = Port Word deriving newtype (Eq, Show)

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -71,13 +71,13 @@ test_serverResponseNoRules =
 -- gRPC server
 ----------------------------------------------------------------------------
 
--- | Start Fencer on port 50051.
+-- | Start Fencer on the default port.
 createServer :: IO (Logger.Logger, ThreadId)
 createServer = do
   (logger, threadId, _) <- createServerAppState
   pure (logger, threadId)
 
--- | Start Fencer on port 50051.
+-- | Start Fencer on the default port.
 createServerAppState :: IO (Logger.Logger, ThreadId, AppState)
 createServerAppState = do
   -- TODO: not the best approach. Ideally we should use e.g.


### PR DESCRIPTION
This patch adds support for configuring the gRPC server port via an environment variable. @neongreen said that ideally the variable's name should be the same as in `lfyt/ratelimit`, but I couldn't find it there so I propose `GRPC_PORT` for the name.

This closes #27.