### PR TITLE
Adds a logger to the GRPC server and polishes a test client configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,12 +56,13 @@ integration:
     - docker network inspect test >/dev/null 2>&1 || docker network create test
 
     # Run Fencer
+    - CNAME="fencer-"$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25 ; echo '')
     - docker load -i fencer.tar.gz
     - docker run
         -v $(pwd)/test_integration_go/config:/srv/runtime_data/current
         -e RUNTIME_SUBDIRECTORY=ratelimit
         -p 50051:50051
-        --name fencer
+        --name $CNAME
         --network test
         --detach
         juspay/fencer
@@ -70,6 +71,6 @@ integration:
     # Run the test
     - docker load -i test_integration_go.tar.gz
     - docker run
-        -e GRPC_HOST=fencer
+        -e GRPC_HOST=$CNAME
         --network test
         test_integration_go

--- a/lib/Fencer/Server.hs
+++ b/lib/Fencer/Server.hs
@@ -45,7 +45,7 @@ runServerWithPort (Port port) logger appState = do
     let options = Grpc.defaultServiceOptions
             { Grpc.serverHost = "0.0.0.0"
             , Grpc.serverPort = fromIntegral port
-              -- TODO: set the logger
+            , Grpc.logger     = Logger.info logger . Logger.msg
             }
     Logger.info logger $
         Logger.msg (("Starting gRPC server at 0.0.0.0:" :: B.ByteString) +++ port)

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -188,4 +188,4 @@ data RuleBranch = RuleBranch
 ----------------------------------------------------------------------------
 
 -- | A network port wrapper
-newtype Port = Port Word deriving newtype (Eq, Show)
+newtype Port = Port { unPort :: Word } deriving newtype (Eq, Show)

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -20,6 +20,8 @@ import qualified Network.GRPC.HighLevel.Generated as Grpc
 
 import           Fencer.AppState
 import           Fencer.Server
+import           Fencer.Settings (defaultGRPCPort)
+import           Fencer.Types (unPort)
 import qualified Fencer.Proto as Proto
 
 ----------------------------------------------------------------------------
@@ -107,7 +109,7 @@ destroyServerAppState (logger, threadId, _) = destroyServer (logger, threadId)
 clientConfig :: Grpc.ClientConfig
 clientConfig = Grpc.ClientConfig
   { Grpc.clientServerHost = "localhost"
-  , Grpc.clientServerPort = 50051
+  , Grpc.clientServerPort = fromIntegral . unPort $ defaultGRPCPort
   , Grpc.clientArgs = []
   , Grpc.clientSSLConfig = Nothing
   , Grpc.clientAuthority = Nothing


### PR DESCRIPTION
This is a simple patch that:

* adds a logger to the GRPC server, and
* polishes a test client configuration.