### PR TITLE
Replace /dev/null with a temporary file that is not system-specific

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -121,8 +121,8 @@ test-suite test-fencer
     , base
     , base-prelude
     , directory
-    , grpc-haskell
     , filepath
+    , grpc-haskell
     , neat-interpolation
     , proto3-wire
     , proto3-suite

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -24,7 +24,7 @@ import qualified StmContainers.Map as StmMap
 import qualified System.IO.Temp as Temp
 import           System.FilePath ((</>))
 import           System.Directory (createDirectoryIfMissing)
-import           Test.Tasty (TestTree, withResource)
+import           Test.Tasty (TestTree)
 import           Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 
 import           Fencer.AppState (appStateCounters, appStateRules, recordHits, setRules)
@@ -32,7 +32,7 @@ import           Fencer.Counter (CounterKey(..), counterHits)
 import           Fencer.Rules
 import           Fencer.Types
 
-import           Fencer.Server.Test (createServerAppState, destroyServerAppState)
+import           Fencer.Server.Test (withServerAppState)
 
 
 -- | Test that 'loadRulesFromDirectory' loads rules from YAML files.
@@ -85,13 +85,13 @@ test_rulesLoadRulesRecursively =
 -- the old one intact.
 test_rulesLimitUnitChange :: TestTree
 test_rulesLimitUnitChange =
-  withResource createServerAppState destroyServerAppState $ \ioLogIdState ->
+  withServerAppState $ \ioLogIdState ->
     testCase "A rule limit unit change on rule reloading" $ do
       Temp.withSystemTempDirectory "fencer-config-unit" $ \tempDir -> do
         createDirectoryIfMissing True (tempDir </> dir)
 
         definitions1 <- writeLoad tempDir merchantLimitsText1
-        (_, _, state) <- ioLogIdState
+        (_, _, _, state) <- ioLogIdState
 
         atomically $ setRules state (mapRuleDefs definitions1)
 

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -32,7 +32,7 @@ import           Fencer.Counter (CounterKey(..), counterHits)
 import           Fencer.Rules
 import           Fencer.Types
 
-import           Fencer.Server.Test (withServerAppState)
+import           Fencer.Server.Test (withServer, serverAppState)
 
 
 -- | Test that 'loadRulesFromDirectory' loads rules from YAML files.
@@ -85,13 +85,13 @@ test_rulesLoadRulesRecursively =
 -- the old one intact.
 test_rulesLimitUnitChange :: TestTree
 test_rulesLimitUnitChange =
-  withServerAppState $ \ioLogIdState ->
+  withServer $ \serverIO ->
     testCase "A rule limit unit change on rule reloading" $ do
       Temp.withSystemTempDirectory "fencer-config-unit" $ \tempDir -> do
         createDirectoryIfMissing True (tempDir </> dir)
 
         definitions1 <- writeLoad tempDir merchantLimitsText1
-        (_, _, _, state) <- ioLogIdState
+        state <- serverAppState <$> serverIO
 
         atomically $ setRules state (mapRuleDefs definitions1)
 

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE GADTs             #-}
 
 -- | Tests for "Fencer.Server".
 module Fencer.Server.Test
   ( test_serverResponseNoRules
-  , withServerAppState
+  , withServer
+  , serverAppState
   )
 where
 
@@ -89,51 +91,45 @@ test_serverResponseNoRules =
 
 -- | A type combining a logger, a handle for the logging file, a
 -- thread id and an application state.
-type LogIdSt = (Logger.Logger, Handle, ThreadId, AppState)
+data Server = Server
+  { serverLogger    :: Logger.Logger
+  , serverLogHandle :: Handle
+  , serverThreadId  :: ThreadId
+  , serverAppState  :: AppState
+  }
 
 -- | Start Fencer on the default port.
-createServer :: IO (Logger.Logger, Handle, ThreadId)
+createServer :: IO Server
 createServer = do
-  (logger, logHandle, threadId, _) <- createServerAppState
-  pure (logger, logHandle, threadId)
-
--- | Start Fencer on the default port.
-createServerAppState :: IO LogIdSt
-createServerAppState = do
   -- TODO: not the best approach. Ideally we should use e.g.
   -- https://hackage.haskell.org/package/tasty-hunit/docs/Test-Tasty-HUnit.html#v:testCaseSteps
   -- but we can't convince @tinylog@ to use the provided step function.
 
   tmpDir <- Temp.getCanonicalTemporaryDirectory
   -- This opens a temporary file in the ReadWrite mode
-  (loggerPath, logHandle) <- Temp.openTempFile tmpDir "fencer-server.log"
+  (loggerPath, serverLogHandle) <- Temp.openTempFile tmpDir "fencer-server.log"
   -- The handle has to be closed. Otherwise trying to create a logger
   -- would fail due to a file lock.
-  hClose logHandle
-  logger <- Logger.create (Logger.Path loggerPath)
-  appState <- initAppState
-  threadId <- forkIO $ runServer logger appState
-  pure (logger, logHandle, threadId, appState)
+  hClose serverLogHandle
+  serverLogger   <- Logger.create (Logger.Path loggerPath)
+  serverAppState <- initAppState
+  serverThreadId <- forkIO $ runServer serverLogger serverAppState
+  pure Server{..}
 
 -- | Kill Fencer.
-destroyServer :: (Logger.Logger, Handle, ThreadId) -> IO ()
-destroyServer (logger, logHandle, threadId) = do
-  Logger.close logger
-  hClose logHandle
-  killThread threadId
-
--- | Kill Fencer.
-destroyServerAppState :: LogIdSt -> IO ()
-destroyServerAppState (logger, logHandle, threadId, _) =
-  destroyServer (logger, logHandle, threadId)
+destroyServer :: Server -> IO ()
+destroyServer server =
+  Logger.close (serverLogger server)
+    `finally` hClose (serverLogHandle server)
+    `finally` killThread (serverThreadId server)
 
 -- | Combines starting and destroying a server in a resource-safe
 -- manner.
-withServerAppState
-  :: (IO LogIdSt -> TestTree)
+withServer
+  :: (IO Server -> TestTree)
   -> TestTree
-withServerAppState =
-  withResource createServerAppState destroyServerAppState
+withServer =
+  withResource createServer destroyServer
 
 ----------------------------------------------------------------------------
 -- gRPC client


### PR DESCRIPTION
This patch:
- addresses and closes #54, and
- improves calling and destroying a server by introducing the `withServerAppState` function.