### PR TITLE
Set the default gRPC server port like in lyft/ratelimit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,6 @@ integration:
     - docker run
         -v $(pwd)/test_integration_go/config:/srv/runtime_data/current
         -e RUNTIME_SUBDIRECTORY=ratelimit
-        -p 50051:50051
         --name $CNAME
         --network test
         --detach

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Fencer-specific environment variables are:
   with names starting with a dot (hidden files on Linux-based systems
   and macOS). It can be `True` or `False`. The default value is
   `False`.
-- `GRPC_PORT` - The port to run the gRPC server on. Default is 50051.
+- `GRPC_PORT` - The port to run the gRPC server on. Default is 8081.
 
 ## Developing
 
@@ -165,7 +165,7 @@ ghz --insecure \
   --call envoy.service.ratelimit.v2.RateLimitService/ShouldRateLimit \
   --data '{"domain":"mongo_cps","descriptors":[{"entries":[{"key":"database","value":"users"}]}]}' \
   -n 50000 \
-  localhost:50051
+  localhost:8081
 ```
 
 Benchmarking lyft/ratelimit:

--- a/lib/Fencer/Settings.hs
+++ b/lib/Fencer/Settings.hs
@@ -17,7 +17,7 @@ import Fencer.Types (Port(..))
 
 -- | The default port for a gRPC server
 defaultGRPCPort :: Port
-defaultGRPCPort = Port 50051
+defaultGRPCPort = Port 8081
 
 -- | Fencer settings.
 data Settings = Settings

--- a/test_integration_go/main.go
+++ b/test_integration_go/main.go
@@ -85,7 +85,7 @@ func testBasicConfig() func(*testing.T) {
 	}
 	grpcPort, grpcPortSet := os.LookupEnv("GRPC_PORT")
 	if !grpcPortSet {
-		grpcPort = "50051"
+		grpcPort = "8081"
 	}
 	return func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
This PR sets the default gRPC server port like in `lyft/ratelimit`.

Closes #63.