### PR TITLE
Give default values for a couple of environment variables in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Logging environment variables are:
 
 - `LOG_BUFFER` - The logging buffer size in bytes.
 - `LOG_LEVEL` - The logging level. It can be one of the following:
-  Trace, Debug, Info, Warn, Error and Fatal.
+  Trace, Debug, Info, Warn, Error and Fatal. The default value is
+  Debug.
 - `LOG_NETSTR` - The flag indicating if netstring encoding is
-  enabled. It can be `True` or `False`.
+  enabled. It can be `True` or `False`. The default value is `False`.
 - `LOG_LEVEL_MAP` - A map for specifying log levels per (named)
   logger. The syntax uses standard haskell syntax for association
   lists of type `[(Text, Level)]`, e.g., `LOG_LEVEL_MAP='[("brown",


### PR DESCRIPTION
This PR gives default values for the environment variables `LOG_LEVEL` and `LOG_NETSTR` in the README. This is per https://github.com/juspay/fencer/pull/52#discussion_r337052241.