### PR TITLE
CI: reverting a change in the Docker network setup and commenting a name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,9 +54,16 @@ integration:
     - docker info
   script:
     # Create a Docker network for the containers
-    - docker network inspect test >/dev/null 2>&1 || docker network create test
+    - docker network create test
 
     # Run Fencer
+
+    # A pipeline would report that a container named "fencer" already
+    # exists (possibly from a job for a different pull request) so
+    # choosing a random container name deals with this
+    # issue. Furthermore, using a named constant helps with informing
+    # where this name is used (compared to "fencer" which has an
+    # overloaded meaning in the CI).
     - CNAME="fencer-"$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 25 ; echo '')
     - docker load -i fencer.tar.gz
     - docker run


### PR DESCRIPTION
This PR makes CI improvements: it reverts a change in the Docker network setup and comments a container name. This is per @neongreen 's comments about updated GitLab runners.