### PR TITLE
Fix the branch name template rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ guidelines we follow:
   first find or open a corresponding issue in the [issue
   tracker](https://github.com/juspay/fencer/issues). Next, create a
   branch based on *master*. The branch should be named in accordance
-  with a template *<github nick>/<issue no>-<description>*, e.g., a
+  with a template `<github nick>/<issue no>-<description>`, e.g., a
   branch could be named *rocketman/42-concurrency-fix*.
 * Once your are satisfied with your contribution branch, [create a
   pull


### PR DESCRIPTION
This simple PR fixes the rendering of a branch name template in the contribution guidelines.

Closes #68.