### PR TITLE
Make sure all exported tests are executed

### DIFF
--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -3,13 +3,7 @@
 {-# LANGUAGE OverloadedLabels  #-}
 
 -- | Tests for "Fencer.Rules".
-module Fencer.Rules.Test
-  ( test_rulesLoadRulesYaml
-  , test_rulesLoadRulesNonYaml
-  , test_rulesLoadRulesRecursively
-  , test_rulesLimitUnitChange
-  )
-where
+module Fencer.Rules.Test (tests) where
 
 import           BasePrelude
 
@@ -24,7 +18,7 @@ import qualified StmContainers.Map as StmMap
 import qualified System.IO.Temp as Temp
 import           System.FilePath ((</>))
 import           System.Directory (createDirectoryIfMissing)
-import           Test.Tasty (TestTree)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 
 import           Fencer.AppState (appStateCounters, appStateRules, recordHits, setRules)
@@ -35,7 +29,15 @@ import           Fencer.Types
 import           Fencer.Server.Test (withServer, serverAppState)
 
 
--- | Test that 'loadRulesFromDirectory' loads rules from YAML files.
+tests :: TestTree
+tests = testGroup "Rule tests"
+  [ test_rulesLoadRulesYaml
+  , test_rulesLoadRulesNonYaml
+  , test_rulesLoadRulesRecursively
+  , test_rulesLimitUnitChange
+  ]
+
+-- | test that 'loadRulesFromDirectory' loads rules from YAML files.
 test_rulesLoadRulesYaml :: TestTree
 test_rulesLoadRulesYaml =
   testCase "Rules are loaded from YAML files" $

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -4,7 +4,7 @@
 
 -- | Tests for "Fencer.Server".
 module Fencer.Server.Test
-  ( test_serverResponseNoRules
+  ( tests
   , withServer
   , serverAppState
   )
@@ -12,7 +12,7 @@ where
 
 import           BasePrelude
 
-import           Test.Tasty (TestTree, withResource)
+import           Test.Tasty (TestTree, testGroup, withResource)
 import           Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 import qualified System.Logger as Logger
 import qualified System.IO.Temp as Temp
@@ -27,6 +27,10 @@ import qualified Fencer.Proto as Proto
 ----------------------------------------------------------------------------
 -- Tests
 ----------------------------------------------------------------------------
+
+tests :: TestTree
+tests = testGroup "Server tests" [ test_serverResponseNoRules ]
+
 
 -- | Test that when Fencer is started without any rules provided to it (i.e.
 -- 'reloadRules' has never been ran), requests to Fencer will error out.

--- a/test/Fencer/Types/Test.hs
+++ b/test/Fencer/Types/Test.hs
@@ -3,14 +3,7 @@
 {-# LANGUAGE TypeApplications  #-}
 
 -- | Tests for types from the "Fencer.Types" module.
-module Fencer.Types.Test
-  ( test_parseJSONDescriptorDefinition
-  , test_parseJSONDomainDefinition
-  , test_parseJSONDomainAtLeastOneDescriptor
-  , test_parseJSONNonEmptyDomainId
-  , test_parseJSONOptionalDescriptorFields
-  )
-where
+module Fencer.Types.Test (tests) where
 
 import           BasePrelude
 
@@ -19,9 +12,18 @@ import           Data.Aeson.QQ (aesonQQ)
 import           Data.Aeson.Types (parseEither, Value(..))
 import           Data.List.NonEmpty (NonEmpty((:|)))
 import           Fencer.Types (DescriptorDefinition(..), DomainDefinition(..), DomainId(..), RateLimit(..), RuleKey(..), RuleValue(..), TimeUnit(..))
-import           Test.Tasty (TestTree)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase)
 
+
+tests :: TestTree
+tests = testGroup "Type tests"
+  [ test_parseJSONDescriptorDefinition
+  , test_parseJSONDomainDefinition
+  , test_parseJSONDomainAtLeastOneDescriptor
+  , test_parseJSONNonEmptyDomainId
+  , test_parseJSONOptionalDescriptorFields
+  ]
 
 descriptor1 :: Value
 descriptor1 = [aesonQQ|

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,44 +1,25 @@
+-- test/Main.hs
 module Main where
 
 import           Test.Tasty (after, defaultMain, testGroup, DependencyType(AllFinish), TestTree)
 
 import           BasePrelude
 
-import qualified Fencer.Rules.Test as R
-import qualified Fencer.Server.Test as S
-import qualified Fencer.Types.Test as T
+import qualified Fencer.Rules.Test
+import qualified Fencer.Server.Test
+import qualified Fencer.Types.Test
 
 
 tests :: TestTree
 tests = testGroup "All tests"
-  [ types
-  , rules
+  [ Fencer.Types.Test.tests
+  , Fencer.Rules.Test.tests
   -- 'after' is needed to avoid running the 'rules' and 'server' tests
   -- concurrently. Running them concurrently is problematic because
   -- both create a server (binding the same port) so if they create it
   -- at the same time, one of the test groups will fail. The 'after'
   -- function makes 'server' tests run after 'rules' tests.
-  , after AllFinish "test_rules" server
-  ]
-
-server :: TestTree
-server = testGroup "Server tests" [S.test_serverResponseNoRules]
-
-rules :: TestTree
-rules = testGroup "Rule tests"
-  [ R.test_rulesLoadRulesYaml
-  , R.test_rulesLoadRulesNonYaml
-  , R.test_rulesLoadRulesRecursively
-  , R.test_rulesLimitUnitChange
-  ]
-
-types :: TestTree
-types = testGroup "Type tests"
-  [ T.test_parseJSONDescriptorDefinition
-  , T.test_parseJSONDomainDefinition
-  , T.test_parseJSONDomainAtLeastOneDescriptor
-  , T.test_parseJSONNonEmptyDomainId
-  , T.test_parseJSONOptionalDescriptorFields
+  , after AllFinish "test_rules" Fencer.Server.Test.tests
   ]
 
 


### PR DESCRIPTION
Per issue #73, this patch reorganises test exports to make it less likely we forget to execute a test. There is a chance we forgot a test, though GHC will report a warning like this in case the test is not in a list of exported tests:

```
test/Fencer/Rules/Test.hs:89:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘test_rulesLimitUnitChange’
   |
89 | test_rulesLimitUnitChange =
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
```

Closes #73.