### PR TITLE
Issue #26: Add a test for rule loading from a dot-directory

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -124,6 +124,7 @@ test-suite test-fencer
     , directory
     , filepath
     , grpc-haskell
+    , named
     , neat-interpolation
     , proto3-wire
     , proto3-suite

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -82,7 +82,8 @@ reloadRules logger settings appState = do
     -- Read and parse the rules
     ruleDefinitions :: [DomainDefinition] <-
         loadRulesFromDirectory
-            (#directory configDir)
+            (#rootDirectory $ settingsRoot settings)
+            (#subDirectory $ settingsSubdirectory settings </> "config")
             (#ignoreDotFiles (settingsIgnoreDotFiles settings))
     Logger.info logger $
         Logger.msg ("Parsed rules for domains: " ++

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -22,7 +22,10 @@ import qualified Data.Yaml as Yaml
 import Fencer.Types
 
 -- | Read rate limiting rules from a directory, recursively. Files are
--- assumed to be YAML, but do not have to have a @.yml@ extension.
+-- assumed to be YAML, but do not have to have a @.yml@ extension. If
+-- any of directories below, including the main sub-directory, starts
+-- with a dot and dot-files are ignored, this function will skip
+-- loading rules from it and all directories below it.
 --
 -- Throws an exception for unparseable or unreadable files.
 loadRulesFromDirectory

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -35,16 +35,14 @@ tests = testGroup "Rule tests"
 -- produces expected result.
 expectLoadRules
   :: "ignoreDotFiles" :! Bool
-  -> "dirTemplate" :! String
   -> "files" :! [(FilePath, Text)]
   -> "result" :! [DomainDefinition]
   -> Assertion
 expectLoadRules
   (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #dirTemplate -> dirTemplate)
   (arg #files -> files)
   (arg #result -> result) =
-  Temp.withSystemTempDirectory dirTemplate $ \tempDir -> do
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
     forM_ files $ \(path, txt) -> do
       let (dir, file) = splitFileName path
       createDirectoryIfMissing True (tempDir </> dir)
@@ -62,7 +60,6 @@ test_rulesLoadRulesYaml =
   testCase "Rules are loaded from YAML files" $
     expectLoadRules
       (#ignoreDotFiles True)
-      (#dirTemplate "fencer-config")
       (#files
         [ ("config1.yml", domain1Text)
         , ("config2.yaml", domain2Text) ]
@@ -76,10 +73,9 @@ test_rulesLoadRulesDotDirectory =
   testCase "Rules are loaded from a dot-directory" $
     expectLoadRules
       (#ignoreDotFiles True)
-      (#dirTemplate ".fencer-config")
       (#files
-        [ ("config1.yml", domain1Text)
-        , ("config2.yaml", domain2Text) ]
+        [ (".domain1/config1.yml", domain1Text)
+        , (".domain2/config2.yaml", domain2Text) ]
       )
       (#result [domain1, domain2])
 
@@ -92,7 +88,6 @@ test_rulesLoadRulesNonYaml =
   testCase "Rules are loaded from non-YAML files" $
     expectLoadRules
       (#ignoreDotFiles True)
-      (#dirTemplate "fencer-config")
       (#files
         [ ("config1.bin", domain1Text)
         , ("config2", domain2Text) ]
@@ -107,7 +102,6 @@ test_rulesLoadRulesRecursively =
   testCase "Rules are loaded recursively" $
     expectLoadRules
       (#ignoreDotFiles True)
-      (#dirTemplate "fencer-config")
       (#files
         [ ("domain1/config.yml", domain1Text)
         , ("domain2/config/config.yml", domain2Text) ]

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLabels  #-}
@@ -10,12 +11,13 @@ import           BasePrelude
 import           Data.List (sortOn)
 import           Data.Text (Text)
 import qualified Data.Text.IO as TIO
+import           Named ((:!), arg)
 import           NeatInterpolation (text)
 import qualified System.IO.Temp as Temp
-import           System.FilePath ((</>))
+import           System.FilePath (splitFileName, (</>))
 import           System.Directory (createDirectoryIfMissing)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (assertEqual, testCase)
+import           Test.Tasty.HUnit (assertEqual, Assertion, testCase)
 
 import           Fencer.Rules
 import           Fencer.Types
@@ -29,35 +31,57 @@ tests = testGroup "Rule tests"
   , test_rulesLoadRulesDotDirectory
   ]
 
--- | A helper function for loading rules and making sure they are as
--- expected.
-loadRules :: String -> Bool -> IO ()
-loadRules dirTemplate ignoreDotFiles =
+-- | Create given directory structure and check that 'loadRulesFromDirectory'
+-- produces expected result.
+expectLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "dirTemplate" :! String
+  -> "files" :! [(FilePath, Text)]
+  -> "result" :! [DomainDefinition]
+  -> Assertion
+expectLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #dirTemplate -> dirTemplate)
+  (arg #files -> files)
+  (arg #result -> result) =
   Temp.withSystemTempDirectory dirTemplate $ \tempDir -> do
-    TIO.writeFile (tempDir </> "config1.yml") domain1Text
-    TIO.writeFile (tempDir </> "config2.yaml") domain2Text
-    definitions <-
-      loadRulesFromDirectory
-        (#directory tempDir)
-        (#ignoreDotFiles ignoreDotFiles)
+    forM_ files $ \(path, txt) -> do
+      let (dir, file) = splitFileName path
+      createDirectoryIfMissing True (tempDir </> dir)
+      TIO.writeFile (tempDir </> dir </> file) txt
+    definitions <- loadRulesFromDirectory
+      (#directory tempDir)
+      (#ignoreDotFiles ignoreDotFiles)
     assertEqual "unexpected definitions"
-      (sortOn domainDefinitionId [domain1, domain2])
+      (sortOn domainDefinitionId result)
       (sortOn domainDefinitionId definitions)
-
 
 -- | test that 'loadRulesFromDirectory' loads rules from YAML files.
 test_rulesLoadRulesYaml :: TestTree
 test_rulesLoadRulesYaml =
   testCase "Rules are loaded from YAML files" $
-    loadRules "fencer-config" True
+    expectLoadRules
+      (#ignoreDotFiles True)
+      (#dirTemplate "fencer-config")
+      (#files
+        [ ("config1.yml", domain1Text)
+        , ("config2.yaml", domain2Text) ]
+      )
+      (#result [domain1, domain2])
 
 -- | test that 'loadRulesFromDirectory' loads rules from a
 -- dot-directory when dot-files should be ignored.
 test_rulesLoadRulesDotDirectory :: TestTree
 test_rulesLoadRulesDotDirectory =
   testCase "Rules are loaded from a dot-directory" $
-    loadRules ".fencer-config" True
-
+    expectLoadRules
+      (#ignoreDotFiles True)
+      (#dirTemplate ".fencer-config")
+      (#files
+        [ ("config1.yml", domain1Text)
+        , ("config2.yaml", domain2Text) ]
+      )
+      (#result [domain1, domain2])
 
 -- | Test that 'loadRulesFromDirectory' loads rules from all files, not just
 -- YAML files.
@@ -66,14 +90,14 @@ test_rulesLoadRulesDotDirectory =
 test_rulesLoadRulesNonYaml :: TestTree
 test_rulesLoadRulesNonYaml =
   testCase "Rules are loaded from non-YAML files" $
-    Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
-      TIO.writeFile (tempDir </> "config1.bin") domain1Text
-      TIO.writeFile (tempDir </> "config2") domain2Text
-      definitions <-
-        loadRulesFromDirectory (#directory tempDir) (#ignoreDotFiles True)
-      assertEqual "unexpected definitions"
-        (sortOn domainDefinitionId [domain1, domain2])
-        (sortOn domainDefinitionId definitions)
+    expectLoadRules
+      (#ignoreDotFiles True)
+      (#dirTemplate "fencer-config")
+      (#files
+        [ ("config1.bin", domain1Text)
+        , ("config2", domain2Text) ]
+      )
+      (#result [domain1, domain2])
 
 -- | Test that 'loadRulesFromDirectory' loads rules recursively.
 --
@@ -81,16 +105,14 @@ test_rulesLoadRulesNonYaml =
 test_rulesLoadRulesRecursively :: TestTree
 test_rulesLoadRulesRecursively =
   testCase "Rules are loaded recursively" $
-    Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
-      createDirectoryIfMissing True (tempDir </> "domain1")
-      TIO.writeFile (tempDir </> "domain1/config.yml") domain1Text
-      createDirectoryIfMissing True (tempDir </> "domain2/config")
-      TIO.writeFile (tempDir </> "domain2/config/config.yml") domain2Text
-      definitions <-
-        loadRulesFromDirectory (#directory tempDir) (#ignoreDotFiles True)
-      assertEqual "unexpected definitions"
-        (sortOn domainDefinitionId [domain1, domain2])
-        (sortOn domainDefinitionId definitions)
+    expectLoadRules
+      (#ignoreDotFiles True)
+      (#dirTemplate "fencer-config")
+      (#files
+        [ ("domain1/config.yml", domain1Text)
+        , ("domain2/config/config.yml", domain2Text) ]
+      )
+      (#result [domain1, domain2])
 
 ----------------------------------------------------------------------------
 -- Sample definitions

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -26,6 +26,7 @@ tests = testGroup "Rule tests"
   [ test_rulesLoadRulesYaml
   , test_rulesLoadRulesNonYaml
   , test_rulesLoadRulesRecursively
+  , test_rulesLoadRulesDotDirectory
   ]
 
 -- | test that 'loadRulesFromDirectory' loads rules from YAML files.
@@ -74,6 +75,21 @@ test_rulesLoadRulesRecursively =
         (sortOn domainDefinitionId [domain1, domain2])
         (sortOn domainDefinitionId definitions)
 
+
+-- | test that 'loadRulesFromDirectory' loads rules from a
+-- dot-directory when dot-files should be ignored.
+test_rulesLoadRulesDotDirectory :: TestTree
+test_rulesLoadRulesDotDirectory =
+  testCase "Rules are loaded from a dot-directory" $
+    Temp.withSystemTempDirectory ".fencer-config" $ \tempDir -> do
+      putStrLn $ show $tempDir
+      TIO.writeFile (tempDir </> "config1.yml") domain1Text
+      TIO.writeFile (tempDir </> "config2.yaml") domain2Text
+      definitions <-
+        loadRulesFromDirectory (#directory tempDir) (#ignoreDotFiles True)
+      assertEqual "unexpected definitions"
+        (sortOn domainDefinitionId [domain1, domain2])
+        (sortOn domainDefinitionId definitions)
 
 ----------------------------------------------------------------------------
 -- Sample definitions

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -48,7 +48,8 @@ expectLoadRules
       createDirectoryIfMissing True (tempDir </> dir)
       TIO.writeFile (tempDir </> dir </> file) txt
     definitions <- loadRulesFromDirectory
-      (#directory tempDir)
+      (#rootDirectory tempDir)
+      (#subDirectory ".")
       (#ignoreDotFiles ignoreDotFiles)
     assertEqual "unexpected definitions"
       (sortOn domainDefinitionId result)
@@ -66,7 +67,7 @@ test_rulesLoadRulesYaml =
       )
       (#result [domain1, domain2])
 
--- | test that 'loadRulesFromDirectory' loads rules from a
+-- | test that 'loadRulesFromDirectory' does not load rules from a
 -- dot-directory when dot-files should be ignored.
 test_rulesLoadRulesDotDirectory :: TestTree
 test_rulesLoadRulesDotDirectory =
@@ -74,10 +75,10 @@ test_rulesLoadRulesDotDirectory =
     expectLoadRules
       (#ignoreDotFiles True)
       (#files
-        [ (".domain1/config1.yml", domain1Text)
-        , (".domain2/config2.yaml", domain2Text) ]
+        [ (".domain1" </> "config1.yml", domain1Text)
+        , ("domain2" </> "config2.yaml", domain2Text) ]
       )
-      (#result [domain1, domain2])
+      (#result [domain2])
 
 -- | Test that 'loadRulesFromDirectory' loads rules from all files, not just
 -- YAML files.
@@ -103,8 +104,8 @@ test_rulesLoadRulesRecursively =
     expectLoadRules
       (#ignoreDotFiles True)
       (#files
-        [ ("domain1/config.yml", domain1Text)
-        , ("domain2/config/config.yml", domain2Text) ]
+        [ ("domain1" </> "config.yml", domain1Text)
+        , ("domain2" </> "config" </> "config.yml", domain2Text) ]
       )
       (#result [domain1, domain2])
 


### PR DESCRIPTION
This confirms that "Would it look at `.foo/bar.yaml` if `RUNTIME_IGNOREDOTFILES` is enabled?" has a positive answer. Ratelimit does the same.