### PR TITLE
Issue #26: Faulty startup parsing

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -82,7 +82,6 @@ library
     directory,
     filepath,
     fsnotify,
-    validation,
     tinylog >= 0.15.0
   hs-source-dirs:
     lib
@@ -136,7 +135,6 @@ test-suite test-fencer
     , text
     , tinylog
     , unordered-containers
-    , validation
     , vector
     , yaml
     -- Internal dependencies

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -138,6 +138,7 @@ test-suite test-fencer
     , unordered-containers
     , validation
     , vector
+    , yaml
     -- Internal dependencies
     , fencer
   ghc-options:

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -81,6 +81,7 @@ library
     directory,
     filepath,
     fsnotify,
+    validation,
     tinylog
   hs-source-dirs:
     lib

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -134,6 +134,7 @@ test-suite test-fencer
     , text
     , tinylog
     , unordered-containers
+    , validation
     , vector
     -- Internal dependencies
     , fencer

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -58,6 +58,7 @@ library
     base,
     base-prelude,
     extra,
+    either,
     hashable,
     monad-loops,
     time,

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -86,7 +86,7 @@ reloadRules logger settings appState = do
         Left fs ->
             Logger.err logger $
                 Logger.msg ("error loading new configuration from runtime: " ++
-                            showErrors fs)
+                            prettyPrintErrors fs)
         Right ruleDefinitions -> do
             Logger.info logger $
                 Logger.msg ("Parsed rules for domains: " ++

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -13,7 +13,6 @@ where
 import BasePrelude
 
 import Control.Concurrent.STM (atomically)
-import Data.Validation (Validation(Success, Failure))
 import System.FilePath ((</>))
 import qualified System.Logger as Logger
 import System.Logger (Logger)
@@ -78,17 +77,17 @@ reloadRules logger settings appState = do
         Logger.msg ("Loading rules from " ++ configDir)
 
     -- Read and parse the rules
-    ruleDefinitionsVal :: Validation [LoadRulesError] [DomainDefinition] <-
+    ruleDefinitionsVal :: Either [LoadRulesError] [DomainDefinition] <-
         loadRulesFromDirectory
             (#rootDirectory $ settingsRoot settings)
             (#subDirectory $ settingsSubdirectory settings </> "config")
             (#ignoreDotFiles (settingsIgnoreDotFiles settings))
     case ruleDefinitionsVal of
-        Failure fs ->
+        Left fs ->
             Logger.err logger $
                 Logger.msg ("error loading new configuration from runtime: " ++
                             showErrors fs)
-        Success ruleDefinitions -> do
+        Right ruleDefinitions -> do
             Logger.info logger $
                 Logger.msg ("Parsed rules for domains: " ++
                     show (map (unDomainId . domainDefinitionId) ruleDefinitions))

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -89,7 +89,7 @@ reloadRules logger settings appState = do
         Failure fs ->
             Logger.err logger $
                 Logger.msg ("error loading new configuration from runtime: " ++
-                            (join . intersperse ", " $ show <$> fs))
+                            showErrors fs)
         Success ruleDefinitions -> do
             Logger.info logger $
                 Logger.msg ("Parsed rules for domains: " ++

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -36,6 +36,9 @@ instance Show LoadRulesError where
     show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
   show (IOEx ex) = "IO exception: " ++ show ex
 
+instance Eq LoadRulesError where
+  e1 == e2 = show e1 == show e2
+
 -- | Show a list of 'LoadRulesError's.
 showErrors :: [LoadRulesError] -> String
 showErrors = join . intersperse ", " . fmap show
@@ -76,7 +79,7 @@ loadRulesFromDirectory
       -> IO (Validation [LoadRulesError] [DomainDefinition])
     combine acc file = do
       let
-        res = fmap liftBoth $
+        res = liftBoth <$>
           catch
             ((mapLeft (ParseException file)) <$> Yaml.decodeFileEither @DomainDefinition file)
             (pure . Left . IOEx)

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -64,9 +64,8 @@ loadRulesFromDirectory
     let filteredFiles = if ignoreDotFiles
         then filter (not . isDotFile) files
         else files
-    (errs, rules) :: ([LoadRulesError], [DomainDefinition]) <-
-      partitionEithers <$> mapM loadFile filteredFiles
-    pure $ if null errs then Right rules else Left errs
+    (errs, rules) <- partitionEithers <$> mapM loadFile filteredFiles
+    pure $ if (null @[] errs) then Right rules else Left errs
   where
     loadFile :: FilePath -> IO (Either LoadRulesError DomainDefinition)
     loadFile file = catch

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -28,16 +28,13 @@ import qualified Data.Yaml as Yaml
 import Fencer.Types
 
 data LoadRulesError
-  = ParseException FilePath Yaml.ParseException
-  | IOEx IOException
+  = LoadRulesParseError FilePath Yaml.ParseException
+  | LoadRulesIOError IOException
 
 instance Show LoadRulesError where
-  show (ParseException file yamlEx) =
+  show (LoadRulesParseError file yamlEx) =
     show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
-  show (IOEx ex) = "IO exception: " ++ show ex
-
-instance Eq LoadRulesError where
-  e1 == e2 = show e1 == show e2
+  show (LoadRulesIOError ex) = "IO error: " ++ show ex
 
 -- | Show a list of 'LoadRulesError's.
 showErrors :: [LoadRulesError] -> String
@@ -81,8 +78,8 @@ loadRulesFromDirectory
       let
         res = liftBoth <$>
           catch
-            ((mapLeft (ParseException file)) <$> Yaml.decodeFileEither @DomainDefinition file)
-            (pure . Left . IOEx)
+            ((mapLeft (LoadRulesParseError file)) <$> Yaml.decodeFileEither @DomainDefinition file)
+            (pure . Left . LoadRulesIOError)
       liftA2 merge res acc
 
     liftBoth

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -64,7 +64,8 @@ loadRulesFromDirectory
     let filteredFiles = if ignoreDotFiles
         then filter (not . isDotFile) files
         else files
-    (errs, rules) <- partitionEithers <$> mapM loadFile filteredFiles
+    (errs, rules) :: ([LoadRulesError], [DomainDefinition]) <-
+      partitionEithers <$> mapM loadFile filteredFiles
     pure $ if null errs then Right rules else Left errs
   where
     loadFile :: FilePath -> IO (Either LoadRulesError DomainDefinition)

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -5,7 +5,7 @@
 -- | Working with rate limiting rules.
 module Fencer.Rules
     ( LoadRulesError(..)
-    , showErrors
+    , prettyPrintErrors
     , loadRulesFromDirectory
     , definitionsToRuleTree
     , applyRules
@@ -29,16 +29,16 @@ import Fencer.Types
 data LoadRulesError
   = LoadRulesParseError FilePath Yaml.ParseException
   | LoadRulesIOError IOException
+  deriving stock (Show)
 
-instance Show LoadRulesError where
-  show (LoadRulesParseError file yamlEx) =
-    show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
-  show (LoadRulesIOError ex) = "IO error: " ++ show ex
-
--- | Show a list of 'LoadRulesError's.
-showErrors :: [LoadRulesError] -> String
-showErrors = join . intersperse ", " . fmap show
-
+-- | Pretty-print a list of 'LoadRulesError's.
+prettyPrintErrors :: [LoadRulesError] -> String
+prettyPrintErrors = intercalate ", " . fmap showError
+  where
+    showError (LoadRulesParseError file yamlEx) =
+      show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
+    showError (LoadRulesIOError ex) =
+      "IO error: " ++ displayException ex
 
 -- | Read rate limiting rules from a directory, recursively. Files are
 -- assumed to be YAML, but do not have to have a @.yml@ extension. If

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -50,11 +50,11 @@ expectLoadRules
       let (dir, file) = splitFileName path
       createDirectoryIfMissing True (tempDir </> dir)
       TIO.writeFile (tempDir </> dir </> file) txt
-    definitionsEither <- loadRulesFromDirectory
+    definitionsVal <- loadRulesFromDirectory
       (#rootDirectory tempDir)
       (#subDirectory ".")
       (#ignoreDotFiles ignoreDotFiles)
-    case definitionsEither of
+    case definitionsVal of
       Failure fs          -> assertFailure $ showErrors fs
       Success definitions -> assertEqual "unexpected definitions"
         (sortOn domainDefinitionId result)

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -154,7 +154,8 @@ test_rulesLoadRulesRecursively =
       (#result $ Right [domain1, domain2])
 
 -- | Test that 'loadRulesFromDirectory' returns exceptions for an
--- invalid domain.
+-- invalid domain. The 'loadRulesFromDirectory' function fails to load
+-- any rules in presence of at least one invalid domain.
 test_rulesLoadRulesException :: TestTree
 test_rulesLoadRulesException =
   testCase "Rules fail to load for an invalid domain" $

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -19,7 +19,7 @@ import qualified System.IO.Temp as Temp
 import           System.FilePath (splitFileName, (</>))
 import           System.Directory (createDirectoryIfMissing)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (assertEqual, Assertion, testCase)
+import           Test.Tasty.HUnit (assertBool, assertEqual, Assertion, testCase)
 
 import           Fencer.Rules
 import           Fencer.Types
@@ -67,9 +67,10 @@ expectLoadRules
           "unexpected failure"
           (length . toErrorList $ result)
           (length . toErrorList $ f)
-      Success definitions -> assertEqual "unexpected definitions"
+      Success definitions -> assertBool "unexpected definitions"
+        (((==) `on` show)
         (sortOn domainDefinitionId <$> result)
-        (Success $ sortOn domainDefinitionId definitions)
+        (Success $ sortOn domainDefinitionId definitions))
  where
   toErrorList :: Validation [LoadRulesError] [DomainDefinition] -> [LoadRulesError]
   toErrorList (Success _) = []
@@ -166,7 +167,7 @@ test_rulesLoadRulesException =
         ]
       )
       (#result $ Failure
-         [ParseException "faultyDomain.yaml" $ Yaml.AesonException ""])
+         [LoadRulesParseError "faultyDomain.yaml" $ Yaml.AesonException ""])
 
 -- | test that 'loadRulesFromDirectory' accepts a minimal
 -- configuration containing only the domain id.


### PR DESCRIPTION
This PR answers a question from issue #26, "What happens if at startup, one rule (out of several) in one domain (out of several) can't be parsed?" Just like Ratelimit, Fencer will fail to parse the rule, but keep on running.

A test is added to confirm that parsing an invalid domain results in an exception.