### PR TITLE
Issue #26: Make the descriptors key optional in the YAML configuration

### DIFF
--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -95,7 +95,7 @@ reloadRules logger settings appState = do
         -- happens with counters during rule reloading.
         setRules appState
             [ ( domainDefinitionId rule
-              , definitionsToRuleTree (NE.toList . domainDefinitionDescriptors $ rule))
+              , definitionsToRuleTree (maybe [] NE.toList (domainDefinitionDescriptors rule)))
             | rule <- ruleDefinitions
             ]
     Logger.info logger $

--- a/lib/Fencer/Main.hs
+++ b/lib/Fencer/Main.hs
@@ -13,7 +13,6 @@ where
 import BasePrelude
 
 import Control.Concurrent.STM (atomically)
-import qualified Data.List.NonEmpty as NE
 import System.FilePath ((</>))
 import qualified System.Logger as Logger
 import System.Logger (Logger)
@@ -95,7 +94,7 @@ reloadRules logger settings appState = do
         -- happens with counters during rule reloading.
         setRules appState
             [ ( domainDefinitionId rule
-              , definitionsToRuleTree (maybe [] NE.toList (domainDefinitionDescriptors rule)))
+              , definitionsToRuleTree $ domainDefinitionDescriptors rule )
             | rule <- ruleDefinitions
             ]
     Logger.info logger $

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -138,7 +138,7 @@ instance FromJSON RateLimit where
 -- Corresponds to one YAML file.
 data DomainDefinition = DomainDefinition
     { domainDefinitionId :: !DomainId
-    , domainDefinitionDescriptors :: !(NE.NonEmpty DescriptorDefinition)
+    , domainDefinitionDescriptors :: !(Maybe (NE.NonEmpty DescriptorDefinition))
     }
     deriving stock (Eq, Show)
 
@@ -156,7 +156,7 @@ instance FromJSON DomainDefinition where
         domainDefinitionId <- o .: "domain"
         when (domainDefinitionId == DomainId "") $
           fail "rate limit domain must not be empty"
-        domainDefinitionDescriptors <- o .: "descriptors"
+        domainDefinitionDescriptors <- o .:? "descriptors"
         pure DomainDefinition{..}
 
 instance FromJSON DescriptorDefinition where

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -38,9 +38,8 @@ import BasePrelude
 
 import Data.Hashable (Hashable)
 import Data.Text (Text)
-import Data.Aeson (FromJSON(..), (.:), (.:?), withObject, withText)
+import Data.Aeson (FromJSON(..), (.:), (.:?), (.!=), withObject, withText)
 import Data.HashMap.Strict (HashMap)
-import qualified Data.List.NonEmpty as NE
 
 
 ----------------------------------------------------------------------------
@@ -138,7 +137,7 @@ instance FromJSON RateLimit where
 -- Corresponds to one YAML file.
 data DomainDefinition = DomainDefinition
     { domainDefinitionId :: !DomainId
-    , domainDefinitionDescriptors :: !(Maybe (NE.NonEmpty DescriptorDefinition))
+    , domainDefinitionDescriptors :: ![DescriptorDefinition]
     }
     deriving stock (Eq, Show)
 
@@ -156,7 +155,7 @@ instance FromJSON DomainDefinition where
         domainDefinitionId <- o .: "domain"
         when (domainDefinitionId == DomainId "") $
           fail "rate limit domain must not be empty"
-        domainDefinitionDescriptors <- o .:? "descriptors"
+        domainDefinitionDescriptors <- o .:? "descriptors" .!= []
         pure DomainDefinition{..}
 
 instance FromJSON DescriptorDefinition where

--- a/test/Fencer/Logic/Test.hs
+++ b/test/Fencer/Logic/Test.hs
@@ -65,7 +65,7 @@ test_logicLimitUnitChange =
   mapRuleDefs :: [DomainDefinition] -> [(DomainId, RuleTree)]
   mapRuleDefs defs =
     [ ( domainDefinitionId rule
-      , definitionsToRuleTree (NE.toList . domainDefinitionDescriptors $ rule))
+      , definitionsToRuleTree (maybe [] NE.toList (domainDefinitionDescriptors rule)))
     | rule <- defs
     ]
 
@@ -89,14 +89,14 @@ test_logicLimitUnitChange =
   definition1 :: DomainDefinition
   definition1 = DomainDefinition
     { domainDefinitionId          = domainId
-    , domainDefinitionDescriptors = descriptor :| []
+    , domainDefinitionDescriptors = Just $ descriptor :| []
     }
 
   definitions1 :: [DomainDefinition]
   definitions1 = [definition1]
 
   definition2 = definition1 {
-    domainDefinitionDescriptors =
+    domainDefinitionDescriptors = Just $
       (descriptor
         { descriptorDefinitionRateLimit = Just $ RateLimit Hour limit }
       ) :| []

--- a/test/Fencer/Logic/Test.hs
+++ b/test/Fencer/Logic/Test.hs
@@ -6,8 +6,6 @@ module Fencer.Logic.Test (tests) where
 
 import           BasePrelude
 
-import           Data.List.NonEmpty (NonEmpty((:|)))
-import qualified Data.List.NonEmpty as NE
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase)
 
@@ -65,7 +63,7 @@ test_logicLimitUnitChange =
   mapRuleDefs :: [DomainDefinition] -> [(DomainId, RuleTree)]
   mapRuleDefs defs =
     [ ( domainDefinitionId rule
-      , definitionsToRuleTree (maybe [] NE.toList (domainDefinitionDescriptors rule)))
+      , definitionsToRuleTree $ domainDefinitionDescriptors rule )
     | rule <- defs
     ]
 
@@ -89,17 +87,17 @@ test_logicLimitUnitChange =
   definition1 :: DomainDefinition
   definition1 = DomainDefinition
     { domainDefinitionId          = domainId
-    , domainDefinitionDescriptors = Just $ descriptor :| []
+    , domainDefinitionDescriptors = [descriptor]
     }
 
   definitions1 :: [DomainDefinition]
   definitions1 = [definition1]
 
   definition2 = definition1 {
-    domainDefinitionDescriptors = Just $
-      (descriptor
+    domainDefinitionDescriptors =
+      [descriptor
         { descriptorDefinitionRateLimit = Just $ RateLimit Hour limit }
-      ) :| []
+      ]
     }
 
   definitions2 :: [DomainDefinition]

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -155,7 +155,7 @@ test_rulesLoadRulesMinimal =
 domain1 :: DomainDefinition
 domain1 = DomainDefinition
   { domainDefinitionId = DomainId "domain1"
-  , domainDefinitionDescriptors = Just $ descriptor1 :| []
+  , domainDefinitionDescriptors = [descriptor1]
   }
   where
     descriptor1 :: DescriptorDefinition
@@ -177,7 +177,7 @@ domain1Text = [text|
 domain2 :: DomainDefinition
 domain2 = DomainDefinition
   { domainDefinitionId = DomainId "domain2"
-  , domainDefinitionDescriptors = Just $ descriptor2 :| []
+  , domainDefinitionDescriptors = [descriptor2]
   }
   where
     descriptor2 :: DescriptorDefinition
@@ -198,7 +198,7 @@ domain2Text = [text|
 minimalDomain :: DomainDefinition
 minimalDomain = DomainDefinition
   { domainDefinitionId = DomainId "min"
-  , domainDefinitionDescriptors = Nothing
+  , domainDefinitionDescriptors = []
   }
 
 minimalDomainText :: Text

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -31,6 +31,7 @@ tests = testGroup "Rule tests"
   , test_rulesLoadRulesDotDirectory
   , test_rulesLoadRules_ignoreDotFiles
   , test_rulesLoadRules_dontIgnoreDotFiles
+  , test_rulesLoadRulesMinimal
   ]
 
 -- | Create given directory structure and check that 'loadRulesFromDirectory'
@@ -135,6 +136,18 @@ test_rulesLoadRulesRecursively =
       )
       (#result [domain1, domain2])
 
+-- | test that 'loadRulesFromDirectory' accepts a minimal
+-- configuration containing only the domain id.
+--
+-- This matches the behavior of @lyft/ratelimit@.
+test_rulesLoadRulesMinimal :: TestTree
+test_rulesLoadRulesMinimal =
+  testCase "Minimal rules contain domain id only" $
+    expectLoadRules
+      (#ignoreDotFiles False)
+      (#files [("min.yaml", minimalDomainText)] )
+      (#result [minimalDomain])
+
 ----------------------------------------------------------------------------
 -- Sample definitions
 ----------------------------------------------------------------------------
@@ -142,7 +155,7 @@ test_rulesLoadRulesRecursively =
 domain1 :: DomainDefinition
 domain1 = DomainDefinition
   { domainDefinitionId = DomainId "domain1"
-  , domainDefinitionDescriptors = descriptor1 :| []
+  , domainDefinitionDescriptors = Just $ descriptor1 :| []
   }
   where
     descriptor1 :: DescriptorDefinition
@@ -164,7 +177,7 @@ domain1Text = [text|
 domain2 :: DomainDefinition
 domain2 = DomainDefinition
   { domainDefinitionId = DomainId "domain2"
-  , domainDefinitionDescriptors = descriptor2 :| []
+  , domainDefinitionDescriptors = Just $ descriptor2 :| []
   }
   where
     descriptor2 :: DescriptorDefinition
@@ -181,3 +194,12 @@ domain2Text = [text|
   descriptors:
     - key: some key 2
   |]
+
+minimalDomain :: DomainDefinition
+minimalDomain = DomainDefinition
+  { domainDefinitionId = DomainId "min"
+  , domainDefinitionDescriptors = Nothing
+  }
+
+minimalDomainText :: Text
+minimalDomainText = [text| domain: min |]

--- a/test/Fencer/Types/Test.hs
+++ b/test/Fencer/Types/Test.hs
@@ -10,7 +10,6 @@ import           BasePrelude
 import           Data.Aeson (parseJSON)
 import           Data.Aeson.QQ (aesonQQ)
 import           Data.Aeson.Types (parseEither, Value(..))
-import           Data.List.NonEmpty (NonEmpty((:|)))
 import           Fencer.Types (DescriptorDefinition(..), DomainDefinition(..), DomainId(..), RateLimit(..), RuleKey(..), RuleValue(..), TimeUnit(..))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertEqual, testCase)
@@ -20,7 +19,7 @@ tests :: TestTree
 tests = testGroup "Type tests"
   [ test_parseJSONDescriptorDefinition
   , test_parseJSONDomainDefinition
-  , test_parseJSONDomainAtLeastOneDescriptor
+  , test_parseJSONDomainEmptyDescriptors
   , test_parseJSONNonEmptyDomainId
   , test_parseJSONOptionalDescriptorFields
   ]
@@ -80,7 +79,7 @@ test_parseJSONDomainDefinition =
   expected :: DomainDefinition
   expected = DomainDefinition
     { domainDefinitionId = DomainId "some domain"
-    , domainDefinitionDescriptors = Just $ descriptor1' :| [descriptor2']
+    , domainDefinitionDescriptors = [descriptor1', descriptor2']
     }
   descriptor1' :: DescriptorDefinition
   descriptor1' = DescriptorDefinition
@@ -97,11 +96,11 @@ test_parseJSONDomainDefinition =
     , descriptorDefinitionDescriptors = Just [descriptor1']
     }
 
-test_parseJSONDomainAtLeastOneDescriptor :: TestTree
-test_parseJSONDomainAtLeastOneDescriptor =
-  testCase "DomainDefinition has to have at least one descriptor" $
+test_parseJSONDomainEmptyDescriptors :: TestTree
+test_parseJSONDomainEmptyDescriptors =
+  testCase "DomainDefinition can have an empty descriptor array" $
     assertEqual "parsing DomainDefinition failed"
-      (Left "Error in $.descriptors: parsing NonEmpty failed, unexpected empty list")
+      (Right $ DomainDefinition (DomainId "some domain #2") [])
       (parseEither (parseJSON @DomainDefinition) domain)
  where
   domain :: Value
@@ -185,5 +184,5 @@ test_parseJSONOptionalDescriptorFields =
   domain = DomainDefinition
     {
       domainDefinitionId          = DomainId "messaging"
-    , domainDefinitionDescriptors = Just $ desc1 :| [desc2]
+    , domainDefinitionDescriptors = [desc1, desc2]
     }

--- a/test/Fencer/Types/Test.hs
+++ b/test/Fencer/Types/Test.hs
@@ -80,7 +80,7 @@ test_parseJSONDomainDefinition =
   expected :: DomainDefinition
   expected = DomainDefinition
     { domainDefinitionId = DomainId "some domain"
-    , domainDefinitionDescriptors = descriptor1' :| [descriptor2']
+    , domainDefinitionDescriptors = Just $ descriptor1' :| [descriptor2']
     }
   descriptor1' :: DescriptorDefinition
   descriptor1' = DescriptorDefinition
@@ -185,5 +185,5 @@ test_parseJSONOptionalDescriptorFields =
   domain = DomainDefinition
     {
       domainDefinitionId          = DomainId "messaging"
-    , domainDefinitionDescriptors = desc1 :| [desc2]
+    , domainDefinitionDescriptors = Just $ desc1 :| [desc2]
     }


### PR DESCRIPTION
This PR addresses the following question from issue #26: "What is the minimal accepted configuration file? Is it the same for Fencer and for lyft/ratelimit?"

Ratelimit accepts a configuration file with a domain id only. This patch adapts Fencer to behave the same. The PR makes the `descriptors` key in YAML configuration files optional. To confirm Fencer accepts such a configuration, a test has been added.