### PR TITLE
Replace the time library with the clock library

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -60,7 +60,7 @@ library
     extra,
     hashable,
     monad-loops,
-    time,
+    clock,
     stm,
     vector,
     text,

--- a/lib/Fencer/Time.hs
+++ b/lib/Fencer/Time.hs
@@ -27,12 +27,11 @@ newtype Timestamp = Timestamp Int64
 
 -- | Get current time as a 'Timestamp'.
 --
--- The 'clock' library is used here because it has support for leap
--- seconds. We do not want to use e.g. the 'time' library's
--- getSystemTime because it will report the same timestamp twice on a
--- leap second. The 'clock' library's getTime function with the
--- Monotonic clock cannot have negative clock jumps and report the
--- same timestamp twice.
+-- We do not want to use e.g. the 'time' library's getSystemTime
+-- because it will report the same timestamp twice on a leap
+-- second. The 'clock' library's getTime function with the Monotonic
+-- clock cannot have negative clock jumps and report the same
+-- timestamp twice.
 getTimestamp :: IO Timestamp
 getTimestamp = Timestamp . sec <$> getTime Monotonic
 

--- a/lib/Fencer/Time.hs
+++ b/lib/Fencer/Time.hs
@@ -14,7 +14,7 @@ import BasePrelude
 
 import Data.Hashable (Hashable)
 import Named ((:!), arg)
-import Data.Time.Clock.System (systemSeconds, getSystemTime)
+import System.Clock (getTime, Clock(Monotonic), sec)
 
 ----------------------------------------------------------------------------
 -- Timestamp
@@ -27,7 +27,7 @@ newtype Timestamp = Timestamp Int64
 
 -- | Get current time as a 'Timestamp'.
 getTimestamp :: IO Timestamp
-getTimestamp = Timestamp . systemSeconds <$> getSystemTime
+getTimestamp = Timestamp . sec <$> getTime Monotonic
 
 -- | Divide time into slots and round a 'Timestamp' up to a slot boundary.
 --

--- a/lib/Fencer/Time.hs
+++ b/lib/Fencer/Time.hs
@@ -26,6 +26,13 @@ newtype Timestamp = Timestamp Int64
     deriving newtype (Hashable, Enum)
 
 -- | Get current time as a 'Timestamp'.
+--
+-- The 'clock' library is used here because it has support for leap
+-- seconds. We do not want to use e.g. the 'time' library's
+-- getSystemTime because it will report the same timestamp twice on a
+-- leap second. The 'clock' library's getTime function with the
+-- Monotonic clock cannot have negative clock jumps and report the
+-- same timestamp twice.
 getTimestamp :: IO Timestamp
 getTimestamp = Timestamp . sec <$> getTime Monotonic
 


### PR DESCRIPTION
This simple patch replaces the `time` library with the `clock` library.

It closes #1.