### PR TITLE
Issue #26: Support handling configuration files without read permissions

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -114,6 +114,7 @@ test-suite test-fencer
     Fencer.Logic.Test
     Fencer.Types.Test
     Fencer.Rules.Test
+    Fencer.Rules.Test.Examples
     Fencer.Rules.Test.Helpers
     Fencer.Rules.Test.Types
     Fencer.Server.Test

--- a/fencer.cabal
+++ b/fencer.cabal
@@ -114,6 +114,8 @@ test-suite test-fencer
     Fencer.Logic.Test
     Fencer.Types.Test
     Fencer.Rules.Test
+    Fencer.Rules.Test.Helpers
+    Fencer.Rules.Test.Types
     Fencer.Server.Test
   default-language:
     Haskell2010

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -69,8 +69,8 @@ loadRulesFromDirectory
     pure $ if (null @[] errs) then Right (catMaybes mRules) else Left errs
   where
     loadFile :: FilePath -> IO (Either LoadRulesError (Maybe DomainDefinition))
-    loadFile file = do
-      ifM (getPermissions file >>= pure . readable)
+    loadFile file =
+      ifM (readable <$> getPermissions file)
         (catch
           (convertParseType file <$> Yaml.decodeFileEither @DomainDefinition file)
           (pure . Left . LoadRulesIOError)

--- a/lib/Fencer/Rules.hs
+++ b/lib/Fencer/Rules.hs
@@ -6,6 +6,7 @@
 module Fencer.Rules
     ( LoadRulesError(..)
     , prettyPrintErrors
+    , showError
     , loadRulesFromDirectory
     , definitionsToRuleTree
     , domainToRuleTree
@@ -32,14 +33,15 @@ data LoadRulesError
   | LoadRulesIOError IOException
   deriving stock (Show)
 
+-- | Pretty-print a 'LoadRulesError'.
+showError :: LoadRulesError -> String
+showError (LoadRulesParseError file yamlEx) =
+  show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
+showError (LoadRulesIOError ex) = "IO error: " ++ displayException ex
+
 -- | Pretty-print a list of 'LoadRulesError's.
 prettyPrintErrors :: [LoadRulesError] -> String
 prettyPrintErrors = intercalate ", " . fmap showError
-  where
-    showError (LoadRulesParseError file yamlEx) =
-      show file ++ ", " ++ (Yaml.prettyPrintParseException yamlEx)
-    showError (LoadRulesIOError ex) =
-      "IO error: " ++ displayException ex
 
 -- | Read rate limiting rules from a directory, recursively. Files are
 -- assumed to be YAML, but do not have to have a @.yml@ extension. If

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -137,7 +137,9 @@ test_rulesLoadRulesException =
         ]
       )
       (#result $ Left
-         [LoadRulesParseError "faultyDomain.yaml" $ Yaml.AesonException ""])
+         [LoadRulesParseError "faultyDomain.yaml" $
+           Yaml.AesonException
+             "Error in $.descriptors[1]: key \"key\" not present"])
 
 -- | test that 'loadRulesFromDirectory' accepts a minimal
 -- configuration containing only the domain id.

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -75,8 +75,7 @@ writeAndLoadRules
   (arg #root -> root)
   (arg #files -> files) = do
 
-  forM_ files $ \(path, txt, permUpdate) ->
-    Fencer.Rules.Test.writeFile
+  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
     (#root root)
     (#path path)
     (#content txt)

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -21,7 +21,7 @@ import qualified Data.Yaml as Yaml
 import           Named ((:!), arg)
 import           NeatInterpolation (text)
 import qualified System.IO.Temp as Temp
-import           System.FilePath (splitFileName, (</>))
+import           System.FilePath (takeDirectory, (</>))
 import qualified System.Directory as Dir
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertBool, assertEqual, Assertion, testCase)
@@ -58,7 +58,7 @@ writeFile
   (arg #modifyPerms -> modifyPerms) = do
 
   let
-    (dir, _) = splitFileName path
+    dir = takeDirectory path
     fullPath = root </> path
   Dir.createDirectoryIfMissing True (root </> dir)
   TIO.writeFile fullPath content

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -161,7 +161,7 @@ test_rulesLoadRulesMinimal =
 test_rulesLoadRulesReadPermissions :: TestTree
 test_rulesLoadRulesReadPermissions =
   testCase "Configuration file read permissions" $
-    expectLoadRulesWithPermissions
+    expectLoadRules
       (#ignoreDotFiles False)
       (#files [file1, file2])
       (#result $ Right [domain2])
@@ -241,12 +241,12 @@ writeAndLoadRules
 -- | Create given directory structure and check that
 -- 'loadRulesFromDirectory' produces expected result such that file
 -- permissions are configurable.
-expectLoadRulesWithPermissions
+expectLoadRules
   :: "ignoreDotFiles" :! Bool
   -> "files" :! [RuleFile]
   -> "result" :! Either [LoadRulesError] [DomainDefinition]
   -> Assertion
-expectLoadRulesWithPermissions
+expectLoadRules
   (arg #ignoreDotFiles -> ignoreDotFiles)
   (arg #files -> files)
   (arg #result -> result) =
@@ -269,23 +269,6 @@ expectLoadRulesWithPermissions
         (((==) `on` show)
         (sortOn domainDefinitionId <$> result)
         (Right $ sortOn domainDefinitionId definitions))
-
--- | Create given directory structure and check that 'loadRulesFromDirectory'
--- produces expected result.
-expectLoadRules
-  :: "ignoreDotFiles" :! Bool
-  -> "files" :! [RuleFile]
-  -> "result" :! Either [LoadRulesError] [DomainDefinition]
-  -> Assertion
-expectLoadRules
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #files -> files)
-  (arg #result -> result) =
-
-  expectLoadRulesWithPermissions
-    (#ignoreDotFiles ignoreDotFiles)
-    (#files files)
-    (#result result)
 
 ----------------------------------------------------------------------------
 -- Sample definitions

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -43,101 +43,6 @@ tests = testGroup "Rule tests"
   , test_rulesLoadRulesReadPermissions
   ]
 
--- | Write contents to a path in the given root and modify file
--- permissions.
-writeFile
-  :: "root" :! FilePath
-  -> "path" :! FilePath
-  -> "content" :! Text
-  -> "modifyPerms" :! (Dir.Permissions -> Dir.Permissions)
-  -> IO ()
-writeFile
-  (arg #root -> root)
-  (arg #path -> path)
-  (arg #content -> content)
-  (arg #modifyPerms -> modifyPerms) = do
-
-  let
-    dir = takeDirectory path
-    fullPath = root </> path
-  Dir.createDirectoryIfMissing True (root </> dir)
-  TIO.writeFile fullPath content
-  perms <- Dir.getPermissions fullPath
-  Dir.setPermissions fullPath (modifyPerms perms)
-
-writeAndLoadRules
-  :: "ignoreDotFiles" :! Bool
-  -> "root" :! FilePath
-  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
-  -> IO (Either [LoadRulesError] [DomainDefinition])
-writeAndLoadRules
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #root -> root)
-  (arg #files -> files) = do
-
-  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
-    (#root root)
-    (#path path)
-    (#content txt)
-    (#modifyPerms permUpdate)
-  loadRulesFromDirectory
-    (#rootDirectory root)
-    (#subDirectory ".")
-    (#ignoreDotFiles ignoreDotFiles)
-
--- | Create given directory structure and check that
--- 'loadRulesFromDirectory' produces expected result such that file
--- permissions are configurable.
-expectLoadRulesWithPermissions
-  :: "ignoreDotFiles" :! Bool
-  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
-  -> "result" :! Either [LoadRulesError] [DomainDefinition]
-  -> Assertion
-expectLoadRulesWithPermissions
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #files -> files)
-  (arg #result -> result) =
-  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
-    writeAndLoadRules
-      (#ignoreDotFiles ignoreDotFiles)
-      (#root tempDir)
-      (#files files)
-      >>= \case
-      f@(Left _) ->
-        -- Paths to temporary files vary and there is not much point
-        -- in writing down exact expected exception messages so the
-        -- only assertion made is that the number of exceptions is the
-        -- same.
-        assertEqual
-          "unexpected failure"
-          (length . toErrorList $ result)
-          (length . toErrorList $ f)
-      Right definitions -> assertBool "unexpected definitions"
-        (((==) `on` show)
-        (sortOn domainDefinitionId <$> result)
-        (Right $ sortOn domainDefinitionId definitions))
- where
-  toErrorList :: Either [LoadRulesError] [DomainDefinition] -> [LoadRulesError]
-  toErrorList (Right _) = []
-  toErrorList (Left fs) = fs
-
--- | Create given directory structure and check that 'loadRulesFromDirectory'
--- produces expected result.
-expectLoadRules
-  :: "ignoreDotFiles" :! Bool
-  -> "files" :! [(FilePath, Text)]
-  -> "result" :! Either [LoadRulesError] [DomainDefinition]
-  -> Assertion
-expectLoadRules
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #files -> files)
-  (arg #result -> result) =
-
-  expectLoadRulesWithPermissions
-    (#ignoreDotFiles ignoreDotFiles)
-    (#files (map (\(path, txt) -> (path, txt, id)) files))
-    (#result result)
-
 -- | test that 'loadRulesFromDirectory' loads rules from YAML files.
 test_rulesLoadRulesYaml :: TestTree
 test_rulesLoadRulesYaml =
@@ -258,6 +163,108 @@ test_rulesLoadRulesReadPermissions =
         , ("domain2" </> "config" </> "config.yml", domain2Text, id) ]
       )
       (#result $ Right [domain2])
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+-- | Get a list of values on the Left or an empty list if it is a
+-- Right value.
+toErrorList :: Either [a] [b] -> [a]
+toErrorList (Right _) = []
+toErrorList (Left xs) = xs
+
+-- | Write contents to a path in the given root and modify file
+-- permissions.
+writeFile
+  :: "root" :! FilePath
+  -> "path" :! FilePath
+  -> "content" :! Text
+  -> "modifyPerms" :! (Dir.Permissions -> Dir.Permissions)
+  -> IO ()
+writeFile
+  (arg #root -> root)
+  (arg #path -> path)
+  (arg #content -> content)
+  (arg #modifyPerms -> modifyPerms) = do
+
+  let
+    dir = takeDirectory path
+    fullPath = root </> path
+  Dir.createDirectoryIfMissing True (root </> dir)
+  TIO.writeFile fullPath content
+  perms <- Dir.getPermissions fullPath
+  Dir.setPermissions fullPath (modifyPerms perms)
+
+-- | Write the content of files at the given root and load the files.
+writeAndLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "root" :! FilePath
+  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+  -> IO (Either [LoadRulesError] [DomainDefinition])
+writeAndLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #root -> root)
+  (arg #files -> files) = do
+
+  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
+    (#root root)
+    (#path path)
+    (#content txt)
+    (#modifyPerms permUpdate)
+  loadRulesFromDirectory
+    (#rootDirectory root)
+    (#subDirectory ".")
+    (#ignoreDotFiles ignoreDotFiles)
+
+-- | Create given directory structure and check that
+-- 'loadRulesFromDirectory' produces expected result such that file
+-- permissions are configurable.
+expectLoadRulesWithPermissions
+  :: "ignoreDotFiles" :! Bool
+  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+  -> "result" :! Either [LoadRulesError] [DomainDefinition]
+  -> Assertion
+expectLoadRulesWithPermissions
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #files -> files)
+  (arg #result -> result) =
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
+    writeAndLoadRules
+      (#ignoreDotFiles ignoreDotFiles)
+      (#root tempDir)
+      (#files files)
+      >>= \case
+      f@(Left _) ->
+        -- Paths to temporary files vary and there is not much point
+        -- in writing down exact expected exception messages so the
+        -- only assertion made is that the number of exceptions is the
+        -- same.
+        assertEqual
+          "unexpected failure"
+          (length . toErrorList $ result)
+          (length . toErrorList $ f)
+      Right definitions -> assertBool "unexpected definitions"
+        (((==) `on` show)
+        (sortOn domainDefinitionId <$> result)
+        (Right $ sortOn domainDefinitionId definitions))
+
+-- | Create given directory structure and check that 'loadRulesFromDirectory'
+-- produces expected result.
+expectLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "files" :! [(FilePath, Text)]
+  -> "result" :! Either [LoadRulesError] [DomainDefinition]
+  -> Assertion
+expectLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #files -> files)
+  (arg #result -> result) =
+
+  expectLoadRulesWithPermissions
+    (#ignoreDotFiles ignoreDotFiles)
+    (#files (map (\(path, txt) -> (path, txt, id)) files))
+    (#result result)
 
 ----------------------------------------------------------------------------
 -- Sample definitions

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -189,13 +189,13 @@ toErrorList (Left xs) = xs
 -- its contents and file permissions.
 data RuleFile = MkRuleFile
   {  -- | The path to the file
-    path :: FilePath
+    ruleFilePath :: FilePath
     -- | The contents of the file in plain text
-  , contents :: Text
+  , ruleFileContents :: Text
     -- | A function specifying how the file permissions should be
     -- changed, i.e., what they should be once the file is written to
     -- disk.
-  , modifyPermissions :: Dir.Permissions -> Dir.Permissions
+  , ruleFileModifyPermissions :: Dir.Permissions -> Dir.Permissions
   }
 
 simpleRuleFile :: FilePath -> Text -> RuleFile
@@ -212,12 +212,12 @@ writeFile
   (arg #file -> file) = do
 
   let
-    dir = takeDirectory (path file)
-    fullPath = root </> (path file)
+    dir = takeDirectory (ruleFilePath file)
+    fullPath = root </> (ruleFilePath file)
   Dir.createDirectoryIfMissing True (root </> dir)
-  TIO.writeFile fullPath (contents file)
+  TIO.writeFile fullPath (ruleFileContents file)
   perms <- Dir.getPermissions fullPath
-  Dir.setPermissions fullPath (modifyPermissions file perms)
+  Dir.setPermissions fullPath (ruleFileModifyPermissions file perms)
 
 -- | Write the content of files at the given root and load the files.
 writeAndLoadRules

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -98,7 +98,7 @@ expectLoadRulesWithPermissions
   (arg #ignoreDotFiles -> ignoreDotFiles)
   (arg #files -> files)
   (arg #result -> result) =
-  Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
     writeAndLoadRules
       (#ignoreDotFiles ignoreDotFiles)
       (#root tempDir)

--- a/test/Fencer/Rules/Test/Examples.hs
+++ b/test/Fencer/Rules/Test/Examples.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+-- | Values used for rule and server testing.
+module Fencer.Rules.Test.Examples
+  ( domainDescriptorKeyValue
+  , domainDescriptorKeyValueText
+  , domainDescriptorKey
+  , domainDescriptorKeyText
+  , faultyDomain
+  , minimalDomain
+  , minimalDomainText
+  , separatorDomain
+  , separatorDomainText
+  )
+  where
+
+import           BasePrelude
+
+import           Data.Text (Text)
+import           NeatInterpolation (text)
+
+import           Fencer.Types
+
+
+-- | A descriptor definition with a key and value only.
+descriptorKeyValue :: DescriptorDefinition
+descriptorKeyValue = DescriptorDefinition
+  { descriptorDefinitionKey = RuleKey "some key"
+  , descriptorDefinitionValue = Just $ RuleValue "some value"
+  , descriptorDefinitionRateLimit = Nothing
+  , descriptorDefinitionDescriptors = Nothing
+  }
+
+-- | A descriptor definition with a key only.
+descriptorKey :: DescriptorDefinition
+descriptorKey = DescriptorDefinition
+  { descriptorDefinitionKey = RuleKey "some key 2"
+  , descriptorDefinitionValue = Nothing
+  , descriptorDefinitionRateLimit = Nothing
+  , descriptorDefinitionDescriptors = Nothing
+  }
+
+-- | A domain definition with a single descriptor with a key and
+-- value.
+domainDescriptorKeyValue :: DomainDefinition
+domainDescriptorKeyValue = DomainDefinition
+  { domainDefinitionId = DomainId "domain1"
+  , domainDefinitionDescriptors = [descriptorKeyValue]
+  }
+
+-- | The text value corresponding to 'domainDescriptorKeyValue'.
+domainDescriptorKeyValueText :: Text
+domainDescriptorKeyValueText = [text|
+  domain: domain1
+  descriptors:
+    - key: some key
+      value: some value
+  |]
+
+-- | A domain definition with a single descriptor with a key.
+domainDescriptorKey :: DomainDefinition
+domainDescriptorKey = DomainDefinition
+  { domainDefinitionId = DomainId "domain2"
+  , domainDefinitionDescriptors = [descriptorKey]
+  }
+
+domainDescriptorKeyText :: Text
+domainDescriptorKeyText = [text|
+  domain: domain2
+  descriptors:
+    - key: some key 2
+  |]
+
+-- | A faulty domain text. The text has "keyz" instead of "key", which
+-- makes domain parsers fail.
+faultyDomain :: Text
+faultyDomain = [text|
+  domain: another
+  descriptors:
+    - key: key2
+      rate_limit:
+        unit: minute
+        requests_per_unit: 20
+    - keyz: key3
+      rate_limit:
+        unit: hour
+        requests_per_unit: 10
+  |]
+
+-- | A minimal domain definition comprised of the domain ID only.
+minimalDomain :: DomainDefinition
+minimalDomain = DomainDefinition
+  { domainDefinitionId = DomainId "min"
+  , domainDefinitionDescriptors = []
+  }
+
+-- | The text value corresponding to 'minimalDomain'.
+minimalDomainText :: Text
+minimalDomainText = [text| domain: min |]
+
+-- | A domain definition with one key with a value and one key without
+-- a value. The result of parsing 'separatorDomainText' has to be this
+-- value.
+separatorDomain :: DomainDefinition
+separatorDomain = DomainDefinition
+  { domainDefinitionId = DomainId "another"
+  , domainDefinitionDescriptors = [descriptorKeyValue, descriptorKey]
+  }
+
+-- | The text value that starts with a YAML document separator. It
+-- corresponds to 'separatorDomain'.
+separatorDomainText :: Text
+separatorDomainText = [text|
+  ---
+  domain: another
+  descriptors:
+    - key: some key
+      value: some value
+    - key: some key 2
+  |]

--- a/test/Fencer/Rules/Test/Helpers.hs
+++ b/test/Fencer/Rules/Test/Helpers.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedLabels  #-}
+
+-- | Module with helper functions used in rules and other testing.
+module Fencer.Rules.Test.Helpers
+  ( toErrorList
+  , writeContentsToFile
+  , writeAndLoadRules
+  , expectLoadRules
+  )
+where
+
+import           BasePrelude
+
+import qualified Data.Text.IO as TIO
+import           Named ((:!), arg)
+import qualified System.Directory as Dir
+import           System.FilePath (FilePath, takeDirectory, (</>))
+import qualified System.IO.Temp as Temp
+import           Test.Tasty.HUnit (assertBool, assertEqual, Assertion)
+
+import           Fencer.Rules (LoadRulesError(..), loadRulesFromDirectory)
+import           Fencer.Rules.Test.Types (RuleFile(..))
+import           Fencer.Types (DomainDefinition(..))
+
+-- | Get a list of values on the Left or an empty list if it is a
+-- Right value.
+toErrorList :: Either [a] [b] -> [a]
+toErrorList (Right _) = []
+toErrorList (Left xs) = xs
+
+-- | Write contents to a path in the given root and modify file
+-- permissions.
+writeContentsToFile
+  :: "root" :! FilePath
+  -> "file" :! RuleFile
+  -> IO ()
+writeContentsToFile
+  (arg #root -> root)
+  (arg #file -> file) = do
+
+  let
+    dir = takeDirectory (ruleFilePath file)
+    fullPath = root </> (ruleFilePath file)
+  Dir.createDirectoryIfMissing True (root </> dir)
+  TIO.writeFile fullPath (ruleFileContents file)
+  perms <- Dir.getPermissions fullPath
+  Dir.setPermissions fullPath (ruleFileModifyPermissions file perms)
+
+-- | Write the content of files at the given root and load the files.
+writeAndLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "root" :! FilePath
+  -> "files" :! [RuleFile]
+  -> IO (Either [LoadRulesError] [DomainDefinition])
+writeAndLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #root -> root)
+  (arg #files -> files) = do
+
+  forM_ files $ \file -> writeContentsToFile
+    (#root root)
+    (#file file)
+  loadRulesFromDirectory
+    (#rootDirectory root)
+    (#subDirectory ".")
+    (#ignoreDotFiles ignoreDotFiles)
+
+-- | Create given directory structure and check that
+-- 'loadRulesFromDirectory' produces expected result such that file
+-- permissions are configurable.
+expectLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "files" :! [RuleFile]
+  -> "result" :! Either [LoadRulesError] [DomainDefinition]
+  -> Assertion
+expectLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #files -> files)
+  (arg #result -> result) =
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
+    writeAndLoadRules
+      (#ignoreDotFiles ignoreDotFiles)
+      (#root tempDir)
+      (#files files)
+      >>= \case
+      f@(Left _) ->
+        -- Paths to temporary files vary and there is not much point
+        -- in writing down exact expected exception messages so the
+        -- only assertion made is that the number of exceptions is the
+        -- same.
+        assertEqual
+          "unexpected failure"
+          (length . toErrorList $ result)
+          (length . toErrorList $ f)
+      Right definitions -> assertBool "unexpected definitions"
+        (((==) `on` show)
+        (sortOn domainDefinitionId <$> result)
+        (Right $ sortOn domainDefinitionId definitions))
+

--- a/test/Fencer/Rules/Test/Helpers.hs
+++ b/test/Fencer/Rules/Test/Helpers.hs
@@ -78,11 +78,11 @@ expectLoadRules
       (#root tempDir)
       (#files files)
       >>= \case
-      Left errs -> do
+      Left errs ->
         case result of
           Right _ ->
             assertFailure "Expected failures, got domain definitions!"
-          Left expectedErrs -> do
+          Left expectedErrs ->
             assertBool ("Exceptions differ! Expected: " ++
                         (prettyPrintErrors expectedErrs) ++ "\nGot: " ++
                         (prettyPrintErrors errs))

--- a/test/Fencer/Rules/Test/Types.hs
+++ b/test/Fencer/Rules/Test/Types.hs
@@ -1,0 +1,27 @@
+-- | Types useful for rule testing.
+module Fencer.Rules.Test.Types
+  ( RuleFile(..)
+  , simpleRuleFile)
+where
+
+import           BasePrelude
+
+import           Data.Text (Text)
+import qualified System.Directory as Dir
+import           System.FilePath (FilePath)
+
+-- | A record useful in testing, which groups together a file path,
+-- its contents and file permissions.
+data RuleFile = MkRuleFile
+  {  -- | The path to the file
+    ruleFilePath :: FilePath
+    -- | The contents of the file in plain text
+  , ruleFileContents :: Text
+    -- | A function specifying how the file permissions should be
+    -- changed, i.e., what they should be once the file is written to
+    -- disk.
+  , ruleFileModifyPermissions :: Dir.Permissions -> Dir.Permissions
+  }
+
+simpleRuleFile :: FilePath -> Text -> RuleFile
+simpleRuleFile p c = MkRuleFile p c id

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -15,7 +15,6 @@ where
 import           BasePrelude
 
 import           Data.ByteString (ByteString)
-import           Data.Text (Text)
 import qualified Data.Vector as Vector
 import           GHC.Exts (fromList)
 import qualified Network.GRPC.HighLevel.Generated as Grpc
@@ -159,11 +158,16 @@ test_serverResponseReadPermissions =
                 (expectedResponse, Grpc.StatusOk)
                 response
   where
-    files :: [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+    files :: [RTest.RuleFile]
     files =
-      [ ( "domain1" </> "config.yml", RTest.domain1Text
-        , const Dir.emptyPermissions)
-      , ("domain2" </> "config" </> "config.yml", RTest.domain2Text, id) ]
+      [ RTest.MkRuleFile
+          ("domain1" </> "config.yml")
+          RTest.domain1Text
+          (const Dir.emptyPermissions)
+      , RTest.simpleRuleFile
+          ("domain2" </> "config" </> "config.yml")
+          RTest.domain2Text
+      ]
 
     request :: Proto.RateLimitRequest
     request = Proto.RateLimitRequest

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE GADTs             #-}
@@ -13,19 +14,25 @@ where
 
 import           BasePrelude
 
-import           Test.Tasty (TestTree, testGroup, withResource)
-import           Test.Tasty.HUnit (HasCallStack, assertEqual, assertFailure, testCase, Assertion)
+import           Data.ByteString (ByteString)
+import           Data.Text (Text)
+import qualified Data.Vector as Vector
+import           GHC.Exts (fromList)
+import qualified Network.GRPC.HighLevel.Generated as Grpc
+import           Proto3.Suite.Types (Enumerated(..))
+import qualified System.Directory as Dir
+import           System.FilePath ((</>))
 import qualified System.Logger as Logger
 import qualified System.IO.Temp as Temp
-import qualified Network.GRPC.HighLevel.Generated as Grpc
-import           Data.ByteString (ByteString)
-import           GHC.Exts (fromList)
+import           Test.Tasty (TestTree, testGroup, withResource)
+import           Test.Tasty.HUnit (HasCallStack, assertEqual, assertFailure, testCase, Assertion)
 
 import           Fencer.Logic
 import           Fencer.Server
 import           Fencer.Settings (defaultGRPCPort, getLogLevel, newLogger)
 import           Fencer.Types
 import           Fencer.Rules
+import qualified Fencer.Rules.Test as RTest
 import qualified Fencer.Proto as Proto
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
@@ -39,6 +46,7 @@ tests = testGroup "Server tests"
   [ test_serverResponseNoRules
   , test_serverResponseEmptyDomain
   , test_serverResponseEmptyDescriptorList
+  , test_serverOKResponseReadPermissions
   ]
 
 -- | Test that when Fencer is started without any rules provided to it (i.e.
@@ -124,6 +132,64 @@ test_serverResponseEmptyDescriptorList =
       , Proto.rateLimitRequestHitsAddend = 0
       }
 
+-- | Test that a request with a non-empty descriptor list result in an
+-- OK response in presence of a configuration file without read
+-- permissions.
+--
+-- This behavior matches @lyft/ratelimit@.
+test_serverOKResponseReadPermissions :: TestTree
+test_serverOKResponseReadPermissions =
+  withResource createServer destroyServer $ \serverIO ->
+    testCase "OK response with one YAML file without read permissions" $
+      Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
+        server <- serverIO
+        RTest.writeAndLoadRules
+          (#ignoreDotFiles False)
+          (#root tempDir)
+          (#files files)
+          >>= \case
+          Left _ -> assertFailure "Failed to load a valid domain!"
+          Right rules -> do
+            atomically $
+              setRules (serverAppState server) (domainToRuleTree <$> rules)
+            withService server $ \service -> do
+              response <- Proto.rateLimitServiceShouldRateLimit service $
+                Grpc.ClientNormalRequest request 1 mempty
+              expectSuccess
+                (expectedResponse, Grpc.StatusOk)
+                response
+  where
+    files :: [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+    files =
+      [ ( "domain1" </> "config.yml", RTest.domain1Text
+        , const Dir.emptyPermissions)
+      , ("domain2" </> "config" </> "config.yml", RTest.domain2Text, id) ]
+
+    request :: Proto.RateLimitRequest
+    request = Proto.RateLimitRequest
+      { Proto.rateLimitRequestDomain = "domain"
+      , Proto.rateLimitRequestDescriptors =
+          fromList $
+          [ Proto.RateLimitDescriptor $
+              fromList [Proto.RateLimitDescriptor_Entry "key" ""]
+          ]
+      , Proto.rateLimitRequestHitsAddend = 0
+      }
+
+    expectedResponse :: Proto.RateLimitResponse
+    expectedResponse = Proto.RateLimitResponse
+      { rateLimitResponseOverallCode =
+          Enumerated $ Right Proto.RateLimitResponse_CodeOK
+      , rateLimitResponseStatuses = Vector.singleton
+          Proto.RateLimitResponse_DescriptorStatus
+          { rateLimitResponse_DescriptorStatusCode =
+              Enumerated $ Right Proto.RateLimitResponse_CodeOK
+          , rateLimitResponse_DescriptorStatusCurrentLimit = Nothing
+          , rateLimitResponse_DescriptorStatusLimitRemaining = 0
+          }
+      , rateLimitResponseHeaders = Vector.empty
+      }
+
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
@@ -136,12 +202,12 @@ domainDefinitionWithoutRules = DomainDefinition
 
 -- | Assert that a gRPC request is successful and has a specific result and
 -- status code.
-_expectSuccess
+expectSuccess
   :: (HasCallStack, Eq result, Show result)
   => (result, Grpc.StatusCode)
   -> Grpc.ClientResult 'Grpc.Normal result
   -> Assertion
-_expectSuccess expected actual = case actual of
+expectSuccess expected actual = case actual of
   Grpc.ClientErrorResponse actualError ->
     assertFailure $
       "Expected a normal response, got an error response: " ++

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -46,7 +46,7 @@ tests = testGroup "Server tests"
   [ test_serverResponseNoRules
   , test_serverResponseEmptyDomain
   , test_serverResponseEmptyDescriptorList
-  , test_serverOKResponseReadPermissions
+  , test_serverResponseReadPermissions
   ]
 
 -- | Test that when Fencer is started without any rules provided to it (i.e.
@@ -132,13 +132,13 @@ test_serverResponseEmptyDescriptorList =
       , Proto.rateLimitRequestHitsAddend = 0
       }
 
--- | Test that a request with a non-empty descriptor list result in an
+-- | Test that a request with a non-empty descriptor list results in an
 -- OK response in presence of a configuration file without read
 -- permissions.
 --
 -- This behavior matches @lyft/ratelimit@.
-test_serverOKResponseReadPermissions :: TestTree
-test_serverOKResponseReadPermissions =
+test_serverResponseReadPermissions :: TestTree
+test_serverResponseReadPermissions =
   withResource createServer destroyServer $ \serverIO ->
     testCase "OK response with one YAML file without read permissions" $
       Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -31,7 +31,7 @@ import           Fencer.Server
 import           Fencer.Settings (defaultGRPCPort, getLogLevel, newLogger)
 import           Fencer.Types
 import           Fencer.Rules
-import qualified Fencer.Rules.Test as RTest
+import           Fencer.Rules.Test.Examples (domainDescriptorKeyValueText, domainDescriptorKeyText)
 import           Fencer.Rules.Test.Helpers (writeAndLoadRules)
 import           Fencer.Rules.Test.Types (RuleFile(..), simpleRuleFile)
 import qualified Fencer.Proto as Proto
@@ -164,11 +164,11 @@ test_serverResponseReadPermissions =
     files =
       [ MkRuleFile
           ("domain1" </> "config.yml")
-          RTest.domain1Text
+          domainDescriptorKeyValueText
           (const Dir.emptyPermissions)
       , simpleRuleFile
           ("domain2" </> "config" </> "config.yml")
-          RTest.domain2Text
+          domainDescriptorKeyText
       ]
 
     request :: Proto.RateLimitRequest

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -32,6 +32,8 @@ import           Fencer.Settings (defaultGRPCPort, getLogLevel, newLogger)
 import           Fencer.Types
 import           Fencer.Rules
 import qualified Fencer.Rules.Test as RTest
+import           Fencer.Rules.Test.Helpers (writeAndLoadRules)
+import           Fencer.Rules.Test.Types (RuleFile(..), simpleRuleFile)
 import qualified Fencer.Proto as Proto
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
@@ -142,7 +144,7 @@ test_serverResponseReadPermissions =
     testCase "OK response with one YAML file without read permissions" $
       Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
         server <- serverIO
-        RTest.writeAndLoadRules
+        writeAndLoadRules
           (#ignoreDotFiles False)
           (#root tempDir)
           (#files files)
@@ -158,13 +160,13 @@ test_serverResponseReadPermissions =
                 (expectedResponse, Grpc.StatusOk)
                 response
   where
-    files :: [RTest.RuleFile]
+    files :: [RuleFile]
     files =
-      [ RTest.MkRuleFile
+      [ MkRuleFile
           ("domain1" </> "config.yml")
           RTest.domain1Text
           (const Dir.emptyPermissions)
-      , RTest.simpleRuleFile
+      , simpleRuleFile
           ("domain2" </> "config" </> "config.yml")
           RTest.domain2Text
       ]


### PR DESCRIPTION
This PR addresses the following remark from issue #26: "When lyft/ratelimit can't read a file (e.g. `chmod 0`-ed), other files are loaded correctly and it responds to requests with OK." Fencer now matches the behavior.

Also see a discussion in an [issue #26 comment](https://github.com/juspay/fencer/issues/26#issuecomment-552796854).