### PR TITLE
Issue #26: No configuration directory

### DIFF
--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -75,8 +75,7 @@ writeAndLoadRules
   (arg #root -> root)
   (arg #files -> files) = do
 
-  forM_ files $ \(path, txt, permUpdate) ->
-    Fencer.Rules.Test.writeFile
+  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
     (#root root)
     (#path path)
     (#content txt)

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -21,7 +21,7 @@ import qualified Data.Yaml as Yaml
 import           Named ((:!), arg)
 import           NeatInterpolation (text)
 import qualified System.IO.Temp as Temp
-import           System.FilePath (splitFileName, (</>))
+import           System.FilePath (takeDirectory, (</>))
 import qualified System.Directory as Dir
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (assertBool, assertEqual, Assertion, testCase)
@@ -58,7 +58,7 @@ writeFile
   (arg #modifyPerms -> modifyPerms) = do
 
   let
-    (dir, _) = splitFileName path
+    dir = takeDirectory path
     fullPath = root </> path
   Dir.createDirectoryIfMissing True (root </> dir)
   TIO.writeFile fullPath content

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -43,101 +43,6 @@ tests = testGroup "Rule tests"
   , test_rulesLoadRulesReadPermissions
   ]
 
--- | Write contents to a path in the given root and modify file
--- permissions.
-writeFile
-  :: "root" :! FilePath
-  -> "path" :! FilePath
-  -> "content" :! Text
-  -> "modifyPerms" :! (Dir.Permissions -> Dir.Permissions)
-  -> IO ()
-writeFile
-  (arg #root -> root)
-  (arg #path -> path)
-  (arg #content -> content)
-  (arg #modifyPerms -> modifyPerms) = do
-
-  let
-    dir = takeDirectory path
-    fullPath = root </> path
-  Dir.createDirectoryIfMissing True (root </> dir)
-  TIO.writeFile fullPath content
-  perms <- Dir.getPermissions fullPath
-  Dir.setPermissions fullPath (modifyPerms perms)
-
-writeAndLoadRules
-  :: "ignoreDotFiles" :! Bool
-  -> "root" :! FilePath
-  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
-  -> IO (Either [LoadRulesError] [DomainDefinition])
-writeAndLoadRules
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #root -> root)
-  (arg #files -> files) = do
-
-  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
-    (#root root)
-    (#path path)
-    (#content txt)
-    (#modifyPerms permUpdate)
-  loadRulesFromDirectory
-    (#rootDirectory root)
-    (#subDirectory ".")
-    (#ignoreDotFiles ignoreDotFiles)
-
--- | Create given directory structure and check that
--- 'loadRulesFromDirectory' produces expected result such that file
--- permissions are configurable.
-expectLoadRulesWithPermissions
-  :: "ignoreDotFiles" :! Bool
-  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
-  -> "result" :! Either [LoadRulesError] [DomainDefinition]
-  -> Assertion
-expectLoadRulesWithPermissions
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #files -> files)
-  (arg #result -> result) =
-  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
-    writeAndLoadRules
-      (#ignoreDotFiles ignoreDotFiles)
-      (#root tempDir)
-      (#files files)
-      >>= \case
-      f@(Left _) ->
-        -- Paths to temporary files vary and there is not much point
-        -- in writing down exact expected exception messages so the
-        -- only assertion made is that the number of exceptions is the
-        -- same.
-        assertEqual
-          "unexpected failure"
-          (length . toErrorList $ result)
-          (length . toErrorList $ f)
-      Right definitions -> assertBool "unexpected definitions"
-        (((==) `on` show)
-        (sortOn domainDefinitionId <$> result)
-        (Right $ sortOn domainDefinitionId definitions))
- where
-  toErrorList :: Either [LoadRulesError] [DomainDefinition] -> [LoadRulesError]
-  toErrorList (Right _) = []
-  toErrorList (Left fs) = fs
-
--- | Create given directory structure and check that 'loadRulesFromDirectory'
--- produces expected result.
-expectLoadRules
-  :: "ignoreDotFiles" :! Bool
-  -> "files" :! [(FilePath, Text)]
-  -> "result" :! Either [LoadRulesError] [DomainDefinition]
-  -> Assertion
-expectLoadRules
-  (arg #ignoreDotFiles -> ignoreDotFiles)
-  (arg #files -> files)
-  (arg #result -> result) =
-
-  expectLoadRulesWithPermissions
-    (#ignoreDotFiles ignoreDotFiles)
-    (#files (map (\(path, txt) -> (path, txt, id)) files))
-    (#result result)
-
 -- | test that 'loadRulesFromDirectory' loads rules from YAML files.
 test_rulesLoadRulesYaml :: TestTree
 test_rulesLoadRulesYaml =
@@ -258,6 +163,108 @@ test_rulesLoadRulesReadPermissions =
         , ("domain2" </> "config" </> "config.yml", domain2Text, id) ]
       )
       (#result $ Right [domain2])
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+-- | Get a list of values on the Left or an empty list if it is a
+-- Right value.
+toErrorList :: Either [a] [b] -> [a]
+toErrorList (Right _) = []
+toErrorList (Left xs) = xs
+
+-- | Write contents to a path in the given root and modify file
+-- permissions.
+writeFile
+  :: "root" :! FilePath
+  -> "path" :! FilePath
+  -> "content" :! Text
+  -> "modifyPerms" :! (Dir.Permissions -> Dir.Permissions)
+  -> IO ()
+writeFile
+  (arg #root -> root)
+  (arg #path -> path)
+  (arg #content -> content)
+  (arg #modifyPerms -> modifyPerms) = do
+
+  let
+    dir = takeDirectory path
+    fullPath = root </> path
+  Dir.createDirectoryIfMissing True (root </> dir)
+  TIO.writeFile fullPath content
+  perms <- Dir.getPermissions fullPath
+  Dir.setPermissions fullPath (modifyPerms perms)
+
+-- | Write the content of files at the given root and load the files.
+writeAndLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "root" :! FilePath
+  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+  -> IO (Either [LoadRulesError] [DomainDefinition])
+writeAndLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #root -> root)
+  (arg #files -> files) = do
+
+  forM_ files $ \(path, txt, permUpdate) -> Fencer.Rules.Test.writeFile
+    (#root root)
+    (#path path)
+    (#content txt)
+    (#modifyPerms permUpdate)
+  loadRulesFromDirectory
+    (#rootDirectory root)
+    (#subDirectory ".")
+    (#ignoreDotFiles ignoreDotFiles)
+
+-- | Create given directory structure and check that
+-- 'loadRulesFromDirectory' produces expected result such that file
+-- permissions are configurable.
+expectLoadRulesWithPermissions
+  :: "ignoreDotFiles" :! Bool
+  -> "files" :! [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+  -> "result" :! Either [LoadRulesError] [DomainDefinition]
+  -> Assertion
+expectLoadRulesWithPermissions
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #files -> files)
+  (arg #result -> result) =
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
+    writeAndLoadRules
+      (#ignoreDotFiles ignoreDotFiles)
+      (#root tempDir)
+      (#files files)
+      >>= \case
+      f@(Left _) ->
+        -- Paths to temporary files vary and there is not much point
+        -- in writing down exact expected exception messages so the
+        -- only assertion made is that the number of exceptions is the
+        -- same.
+        assertEqual
+          "unexpected failure"
+          (length . toErrorList $ result)
+          (length . toErrorList $ f)
+      Right definitions -> assertBool "unexpected definitions"
+        (((==) `on` show)
+        (sortOn domainDefinitionId <$> result)
+        (Right $ sortOn domainDefinitionId definitions))
+
+-- | Create given directory structure and check that 'loadRulesFromDirectory'
+-- produces expected result.
+expectLoadRules
+  :: "ignoreDotFiles" :! Bool
+  -> "files" :! [(FilePath, Text)]
+  -> "result" :! Either [LoadRulesError] [DomainDefinition]
+  -> Assertion
+expectLoadRules
+  (arg #ignoreDotFiles -> ignoreDotFiles)
+  (arg #files -> files)
+  (arg #result -> result) =
+
+  expectLoadRulesWithPermissions
+    (#ignoreDotFiles ignoreDotFiles)
+    (#files (map (\(path, txt) -> (path, txt, id)) files))
+    (#result result)
 
 ----------------------------------------------------------------------------
 -- Sample definitions

--- a/test/Fencer/Rules/Test.hs
+++ b/test/Fencer/Rules/Test.hs
@@ -98,7 +98,7 @@ expectLoadRulesWithPermissions
   (arg #ignoreDotFiles -> ignoreDotFiles)
   (arg #files -> files)
   (arg #result -> result) =
-  Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
+  Temp.withSystemTempDirectory "fencer-config" $ \tempDir ->
     writeAndLoadRules
       (#ignoreDotFiles ignoreDotFiles)
       (#root tempDir)

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE GADTs             #-}
@@ -13,19 +14,25 @@ where
 
 import           BasePrelude
 
-import           Test.Tasty (TestTree, testGroup, withResource)
-import           Test.Tasty.HUnit (HasCallStack, assertEqual, assertFailure, testCase, Assertion)
+import           Data.ByteString (ByteString)
+import           Data.Text (Text)
+import qualified Data.Vector as Vector
+import           GHC.Exts (fromList)
+import qualified Network.GRPC.HighLevel.Generated as Grpc
+import           Proto3.Suite.Types (Enumerated(..))
+import qualified System.Directory as Dir
+import           System.FilePath ((</>))
 import qualified System.Logger as Logger
 import qualified System.IO.Temp as Temp
-import qualified Network.GRPC.HighLevel.Generated as Grpc
-import           Data.ByteString (ByteString)
-import           GHC.Exts (fromList)
+import           Test.Tasty (TestTree, testGroup, withResource)
+import           Test.Tasty.HUnit (HasCallStack, assertEqual, assertFailure, testCase, Assertion)
 
 import           Fencer.Logic
 import           Fencer.Server
 import           Fencer.Settings (defaultGRPCPort, getLogLevel, newLogger)
 import           Fencer.Types
 import           Fencer.Rules
+import qualified Fencer.Rules.Test as RTest
 import qualified Fencer.Proto as Proto
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
@@ -39,6 +46,7 @@ tests = testGroup "Server tests"
   [ test_serverResponseNoRules
   , test_serverResponseEmptyDomain
   , test_serverResponseEmptyDescriptorList
+  , test_serverOKResponseReadPermissions
   ]
 
 -- | Test that when Fencer is started without any rules provided to it (i.e.
@@ -124,6 +132,64 @@ test_serverResponseEmptyDescriptorList =
       , Proto.rateLimitRequestHitsAddend = 0
       }
 
+-- | Test that a request with a non-empty descriptor list result in an
+-- OK response in presence of a configuration file without read
+-- permissions.
+--
+-- This behavior matches @lyft/ratelimit@.
+test_serverOKResponseReadPermissions :: TestTree
+test_serverOKResponseReadPermissions =
+  withResource createServer destroyServer $ \serverIO ->
+    testCase "OK response with one YAML file without read permissions" $
+      Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
+        server <- serverIO
+        RTest.writeAndLoadRules
+          (#ignoreDotFiles False)
+          (#root tempDir)
+          (#files files)
+          >>= \case
+          Left _ -> assertFailure "Failed to load a valid domain!"
+          Right rules -> do
+            atomically $
+              setRules (serverAppState server) (domainToRuleTree <$> rules)
+            withService server $ \service -> do
+              response <- Proto.rateLimitServiceShouldRateLimit service $
+                Grpc.ClientNormalRequest request 1 mempty
+              expectSuccess
+                (expectedResponse, Grpc.StatusOk)
+                response
+  where
+    files :: [(FilePath, Text, Dir.Permissions -> Dir.Permissions)]
+    files =
+      [ ( "domain1" </> "config.yml", RTest.domain1Text
+        , const Dir.emptyPermissions)
+      , ("domain2" </> "config" </> "config.yml", RTest.domain2Text, id) ]
+
+    request :: Proto.RateLimitRequest
+    request = Proto.RateLimitRequest
+      { Proto.rateLimitRequestDomain = "domain"
+      , Proto.rateLimitRequestDescriptors =
+          fromList $
+          [ Proto.RateLimitDescriptor $
+              fromList [Proto.RateLimitDescriptor_Entry "key" ""]
+          ]
+      , Proto.rateLimitRequestHitsAddend = 0
+      }
+
+    expectedResponse :: Proto.RateLimitResponse
+    expectedResponse = Proto.RateLimitResponse
+      { rateLimitResponseOverallCode =
+          Enumerated $ Right Proto.RateLimitResponse_CodeOK
+      , rateLimitResponseStatuses = Vector.singleton
+          Proto.RateLimitResponse_DescriptorStatus
+          { rateLimitResponse_DescriptorStatusCode =
+              Enumerated $ Right Proto.RateLimitResponse_CodeOK
+          , rateLimitResponse_DescriptorStatusCurrentLimit = Nothing
+          , rateLimitResponse_DescriptorStatusLimitRemaining = 0
+          }
+      , rateLimitResponseHeaders = Vector.empty
+      }
+
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
@@ -136,12 +202,12 @@ domainDefinitionWithoutRules = DomainDefinition
 
 -- | Assert that a gRPC request is successful and has a specific result and
 -- status code.
-_expectSuccess
+expectSuccess
   :: (HasCallStack, Eq result, Show result)
   => (result, Grpc.StatusCode)
   -> Grpc.ClientResult 'Grpc.Normal result
   -> Assertion
-_expectSuccess expected actual = case actual of
+expectSuccess expected actual = case actual of
   Grpc.ClientErrorResponse actualError ->
     assertFailure $
       "Expected a normal response, got an error response: " ++

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -46,7 +46,7 @@ tests = testGroup "Server tests"
   [ test_serverResponseNoRules
   , test_serverResponseEmptyDomain
   , test_serverResponseEmptyDescriptorList
-  , test_serverOKResponseReadPermissions
+  , test_serverResponseReadPermissions
   ]
 
 -- | Test that when Fencer is started without any rules provided to it (i.e.
@@ -132,13 +132,13 @@ test_serverResponseEmptyDescriptorList =
       , Proto.rateLimitRequestHitsAddend = 0
       }
 
--- | Test that a request with a non-empty descriptor list result in an
+-- | Test that a request with a non-empty descriptor list results in an
 -- OK response in presence of a configuration file without read
 -- permissions.
 --
 -- This behavior matches @lyft/ratelimit@.
-test_serverOKResponseReadPermissions :: TestTree
-test_serverOKResponseReadPermissions =
+test_serverResponseReadPermissions :: TestTree
+test_serverResponseReadPermissions =
   withResource createServer destroyServer $ \serverIO ->
     testCase "OK response with one YAML file without read permissions" $
       Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do

--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -84,7 +84,7 @@ test_serverResponseNoRules =
 test_serverResponseNoConfigurationDirectory :: TestTree
 test_serverResponseNoConfigurationDirectory =
   withResource createServer destroyServer $ \serverIO ->
-    testCase "In absence of the configuration dir, all responses are OK" $ do
+    testCase "In absence of the configuration dir, all responses are OK" $
       Temp.withSystemTempDirectory "fencer-config" $ \tempDir -> do
         server <- serverIO
         RTest.writeAndLoadRules


### PR DESCRIPTION
This pull request addresses the following remark from issue #26: When lyft/ratelimit doesn't find the dir symlink, it responds to requests with OK.

Fencer behaves the same way and a server test was added to confirm this behavior.

Please review PR #102 first because it and this PR both depend on the `mdimjasevic/26-cant-read-file` branch.