### PR TITLE
Issue #26: Faulty configuration and error responses

### DIFF
--- a/test/Fencer/Server/Test.hs
+++ b/test/Fencer/Server/Test.hs
@@ -44,6 +44,10 @@ tests = testGroup "Server tests"
 -- | Test that when Fencer is started without any rules provided to it (i.e.
 -- 'reloadRules' has never been ran), requests to Fencer will error out.
 --
+-- This test also corresponds to a case when there is faulty
+-- configuration and Fencer loads no rules at startup. In such a case
+-- the server responds to requests with an error.
+--
 -- This behavior matches @lyft/ratelimit@.
 test_serverResponseNoRules :: TestTree
 test_serverResponseNoRules =


### PR DESCRIPTION
This patch addresses the following remark from issue #26: (partly done in #35, not tested properly, not documented) When lyft/ratelimit finds the config dir but even one file is corrupted (broken YAML or correct YAML but broken field names), it responds to requests with ERROR."

Fencer already matches this behavior. Furthermore, there already exists a server test corresponding to this situation, in particular the `Fencer.Server.Test.test_serverResponseNoRules` test, as it is currently called in `master`. When there is faulty configuration, an error will be returned in response, which is what the test is about.
