### PR TITLE
Introduce a descriptor sum type to better reflect the domain logic

### DIFF
--- a/fencer.cabal
+++ b/fencer.cabal
@@ -39,6 +39,7 @@ common common
     -Wincomplete-record-updates
     -Wincomplete-uni-patterns
     -Wredundant-constraints
+    -Wpartial-fields
 
 library
   import:

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -168,10 +168,7 @@ data DescriptorDefinition
       !RuleKey
       !(Maybe RuleValue)
       !RateLimit
-
-deriving instance Eq DescriptorDefinition
-deriving instance Show DescriptorDefinition
-
+  deriving stock (Eq, Show)
 
 descriptorDefinitionKey
   :: DescriptorDefinition

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -173,7 +173,7 @@ instance HasDescriptors DomainDefinition where
   descriptorsOf = domainDefinitionDescriptors
 
 instance HasDescriptors DescriptorDefinition where
-  descriptorsOf (DescriptorDefinitionLeafNode _ _ _)  = []
+  descriptorsOf (DescriptorDefinitionLeafNode{})      = []
   descriptorsOf (DescriptorDefinitionInnerNode _ _ l) = l
 
 instance FromJSON DomainDefinition where

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -156,22 +155,19 @@ data DomainDefinition = DomainDefinition
     deriving stock (Eq, Show)
 
 -- | Config for a single rule tree.
-data DescriptorDefinition where
-  -- | An inner node with no rate limit
-  DescriptorDefinitionInnerNode
-    :: !RuleKey
-    -> !(Maybe RuleValue)
-    -> ![DescriptorDefinition]
-       -----------------------
-    -> DescriptorDefinition
+data DescriptorDefinition
+  =
+    -- | An inner node with no rate limit
+    DescriptorDefinitionInnerNode
+      !RuleKey
+      !(Maybe RuleValue)
+      ![DescriptorDefinition]
 
-  -- | A leaf node with a rate limit
-  DescriptorDefinitionLeafNode
-    :: !RuleKey
-    -> !(Maybe RuleValue)
-    -> !RateLimit
-       --------------------
-    -> DescriptorDefinition
+    -- | A leaf node with a rate limit
+  | DescriptorDefinitionLeafNode
+      !RuleKey
+      !(Maybe RuleValue)
+      !RateLimit
 
 deriving instance Eq DescriptorDefinition
 deriving instance Show DescriptorDefinition
@@ -236,9 +232,9 @@ type RuleTree = HashMap (RuleKey, Maybe RuleValue) RuleBranch
 
 -- | A single branch in a rule tree, containing several (or perhaps zero)
 -- nested rules.
-data RuleBranch where
-  RuleBranch :: !RuleTree -> RuleBranch
-  RuleLeaf :: !RateLimit -> RuleBranch
+data RuleBranch
+  = RuleBranch !RuleTree
+  | RuleLeaf !RateLimit
 
 ----------------------------------------------------------------------------
 -- Fencer server

--- a/lib/Fencer/Types.hs
+++ b/lib/Fencer/Types.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE StandaloneDeriving         #-}
 
 -- | Types used in Fencer. We try to keep most types in one module to avoid
 -- circular dependencies between modules.

--- a/test/Fencer/Logic/Test.hs
+++ b/test/Fencer/Logic/Test.hs
@@ -70,11 +70,10 @@ test_logicLimitUnitChange =
   domainId  = DomainId  "merchant_rate_limits"
 
   descriptor :: DescriptorDefinition
-  descriptor = DescriptorDefinition
+  descriptor = DescriptorDefinitionLeafNode
         { descriptorDefinitionKey         = ruleKey
         , descriptorDefinitionValue       = Just ruleValue
-        , descriptorDefinitionRateLimit   = Just $ RateLimit Minute limit
-        , descriptorDefinitionDescriptors = Nothing
+        , descriptorDefinitionRateLimit   = RateLimit Minute limit
         }
 
   definition1 :: DomainDefinition
@@ -88,8 +87,10 @@ test_logicLimitUnitChange =
 
   definition2 = definition1 {
     domainDefinitionDescriptors =
-      [descriptor
-        { descriptorDefinitionRateLimit = Just $ RateLimit Hour limit }
+      [DescriptorDefinitionLeafNode
+        (descriptorDefinitionKey descriptor)
+        (descriptorDefinitionValue descriptor)
+        (RateLimit Hour limit)
       ]
     }
 

--- a/test/Fencer/Logic/Test.hs
+++ b/test/Fencer/Logic/Test.hs
@@ -71,10 +71,9 @@ test_logicLimitUnitChange =
 
   descriptor :: DescriptorDefinition
   descriptor = DescriptorDefinitionLeafNode
-        { descriptorDefinitionKey         = ruleKey
-        , descriptorDefinitionValue       = Just ruleValue
-        , descriptorDefinitionRateLimit   = RateLimit Minute limit
-        }
+    ruleKey
+    (Just ruleValue)
+    (RateLimit Minute limit)
 
   definition1 :: DomainDefinition
   definition1 = DomainDefinition

--- a/test/Fencer/Rules/Test/Examples.hs
+++ b/test/Fencer/Rules/Test/Examples.hs
@@ -27,20 +27,20 @@ import           Fencer.Types
 -- | A leaf descriptor definition with a key, a value and a rate
 -- limit.
 descriptorKeyValue :: DescriptorDefinition
-descriptorKeyValue = DescriptorDefinitionLeafNode
-  { descriptorDefinitionKey = RuleKey "some key"
-  , descriptorDefinitionValue = Just $ RuleValue "some value"
-  , descriptorDefinitionRateLimit = RateLimit Hour 10
-  }
+descriptorKeyValue =
+  DescriptorDefinitionLeafNode
+    (RuleKey "some key")
+    (Just $ RuleValue "some value")
+    (RateLimit Hour 10)
 
 -- | A leaf inner descriptor definition with a key and rate limit
 -- only.
 descriptorKey :: DescriptorDefinition
-descriptorKey = DescriptorDefinitionLeafNode
-  { descriptorDefinitionKey = RuleKey "some key 2"
-  , descriptorDefinitionValue = Nothing
-  , descriptorDefinitionRateLimit = RateLimit Minute 20
-  }
+descriptorKey =
+  DescriptorDefinitionLeafNode
+    (RuleKey "some key 2")
+    Nothing
+    (RateLimit Minute 20)
 
 -- | A domain definition with a single descriptor with a key and
 -- value.

--- a/test/Fencer/Rules/Test/Examples.hs
+++ b/test/Fencer/Rules/Test/Examples.hs
@@ -33,8 +33,7 @@ descriptorKeyValue =
     (Just $ RuleValue "some value")
     (RateLimit Hour 10)
 
--- | A leaf inner descriptor definition with a key and rate limit
--- only.
+-- | A leaf descriptor definition with a key and rate limit only.
 descriptorKey :: DescriptorDefinition
 descriptorKey =
   DescriptorDefinitionLeafNode

--- a/test/Fencer/Rules/Test/Examples.hs
+++ b/test/Fencer/Rules/Test/Examples.hs
@@ -24,22 +24,22 @@ import           NeatInterpolation (text)
 import           Fencer.Types
 
 
--- | A descriptor definition with a key and value only.
+-- | A leaf descriptor definition with a key, a value and a rate
+-- limit.
 descriptorKeyValue :: DescriptorDefinition
-descriptorKeyValue = DescriptorDefinition
+descriptorKeyValue = DescriptorDefinitionLeafNode
   { descriptorDefinitionKey = RuleKey "some key"
   , descriptorDefinitionValue = Just $ RuleValue "some value"
-  , descriptorDefinitionRateLimit = Nothing
-  , descriptorDefinitionDescriptors = Nothing
+  , descriptorDefinitionRateLimit = RateLimit Hour 10
   }
 
--- | A descriptor definition with a key only.
+-- | A leaf inner descriptor definition with a key and rate limit
+-- only.
 descriptorKey :: DescriptorDefinition
-descriptorKey = DescriptorDefinition
+descriptorKey = DescriptorDefinitionLeafNode
   { descriptorDefinitionKey = RuleKey "some key 2"
   , descriptorDefinitionValue = Nothing
-  , descriptorDefinitionRateLimit = Nothing
-  , descriptorDefinitionDescriptors = Nothing
+  , descriptorDefinitionRateLimit = RateLimit Minute 20
   }
 
 -- | A domain definition with a single descriptor with a key and
@@ -57,6 +57,9 @@ domainDescriptorKeyValueText = [text|
   descriptors:
     - key: some key
       value: some value
+      rate_limit:
+        unit: hour
+        requests_per_unit: 10
   |]
 
 -- | A domain definition with a single descriptor with a key.
@@ -71,6 +74,9 @@ domainDescriptorKeyText = [text|
   domain: domain2
   descriptors:
     - key: some key 2
+      rate_limit:
+        unit: minute
+        requests_per_unit: 20
   |]
 
 -- | A faulty domain text. The text has "keyz" instead of "key", which
@@ -118,7 +124,13 @@ separatorDomainText = [text|
   descriptors:
     - key: some key
       value: some value
+      rate_limit:
+        unit: hour
+        requests_per_unit: 10
     - key: some key 2
+      rate_limit:
+        unit: minute
+        requests_per_unit: 20
   |]
 
 -- | The text value of a faulty domain definition that has a key

--- a/test/Fencer/Rules/Test/Helpers.hs
+++ b/test/Fencer/Rules/Test/Helpers.hs
@@ -84,7 +84,7 @@ expectLoadRules
       Left errs ->
         case result of
           Right _ ->
-            assertFailure "Expected failures, got domain definitions!"
+            assertFailure "Expected domain definitions, got failures!"
           Left expectedErrs ->
             assertBool ("Exceptions differ! Expected: " ++
                         (prettyPrintErrors $ NE.toList expectedErrs) ++ "\nGot: " ++

--- a/test/Fencer/Types/Test.hs
+++ b/test/Fencer/Types/Test.hs
@@ -48,11 +48,11 @@ test_parseJSONDescriptorDefinition =
       (parseEither (parseJSON @DescriptorDefinition) descriptor1)
  where
   expected :: DescriptorDefinition
-  expected = DescriptorDefinitionLeafNode
-    { descriptorDefinitionKey = RuleKey "some key"
-    , descriptorDefinitionValue = Just $ RuleValue "some value"
-    , descriptorDefinitionRateLimit = RateLimit Second 5
-    }
+  expected =
+    DescriptorDefinitionLeafNode
+      (RuleKey "some key")
+      (Just $ RuleValue "some value")
+      (RateLimit Second 5)
 
 -- | Test that parsing an invalid inner descriptor definition fails.
 test_parseJSONFaultyDescriptorDefinition1 :: TestTree
@@ -137,16 +137,14 @@ test_parseJSONDomainDefinition =
     }
   descriptor1' :: DescriptorDefinition
   descriptor1' = DescriptorDefinitionLeafNode
-    { descriptorDefinitionKey = RuleKey "some key"
-    , descriptorDefinitionValue = Just $ RuleValue "some value"
-    , descriptorDefinitionRateLimit = RateLimit Second 5
-    }
+    (RuleKey "some key")
+    (Just $ RuleValue "some value")
+    (RateLimit Second 5)
   descriptor2' :: DescriptorDefinition
   descriptor2' = DescriptorDefinitionInnerNode
-    { descriptorDefinitionKey = RuleKey "some key #2"
-    , descriptorDefinitionValue = Just $ RuleValue "some value #2"
-    , descriptorDefinitionDescriptors = [descriptor1']
-    }
+    (RuleKey "some key #2")
+    (Just $ RuleValue "some value #2")
+    [descriptor1']
 
 test_parseJSONDomainEmptyDescriptors :: TestTree
 test_parseJSONDomainEmptyDescriptors =
@@ -196,18 +194,13 @@ test_parseJSONOptionalDescriptorFields =
     |]
   desc1 :: DescriptorDefinition
   desc1 = DescriptorDefinitionInnerNode
-    {
-      descriptorDefinitionKey         = RuleKey "key #1"
-    , descriptorDefinitionValue       = Just . RuleValue $ "value #1"
-    , descriptorDefinitionDescriptors =
-      [ DescriptorDefinitionLeafNode
-        {
-          descriptorDefinitionKey       = RuleKey "inner key #1"
-        , descriptorDefinitionValue     = Nothing
-        , descriptorDefinitionRateLimit = RateLimit Minute 10
-        }
-      ]
-    }
+    (RuleKey "key #1")
+    (Just . RuleValue $ "value #1")
+    [ DescriptorDefinitionLeafNode
+        (RuleKey "inner key #1")
+        Nothing
+        (RateLimit Minute 10)
+    ]
   desc2Value :: Value
   desc2Value = [aesonQQ|
     {
@@ -217,11 +210,9 @@ test_parseJSONOptionalDescriptorFields =
     |]
   desc2 :: DescriptorDefinition
   desc2 = DescriptorDefinitionLeafNode
-    {
-      descriptorDefinitionKey         = RuleKey "key #2"
-    , descriptorDefinitionValue       = Nothing
-    , descriptorDefinitionRateLimit   = RateLimit Hour 1000
-    }
+    (RuleKey "key #2")
+    Nothing
+    (RateLimit Hour 1000)
   domainValue :: Value
   domainValue = [aesonQQ|
     {

--- a/test/Fencer/Types/Test.hs
+++ b/test/Fencer/Types/Test.hs
@@ -18,6 +18,8 @@ import           Test.Tasty.HUnit (assertEqual, testCase)
 tests :: TestTree
 tests = testGroup "Type tests"
   [ test_parseJSONDescriptorDefinition
+  , test_parseJSONFaultyDescriptorDefinition1
+  , test_parseJSONFaultyDescriptorDefinition2
   , test_parseJSONDomainDefinition
   , test_parseJSONDomainEmptyDescriptors
   , test_parseJSONNonEmptyDomainId
@@ -28,36 +30,88 @@ descriptor1 :: Value
 descriptor1 = [aesonQQ|
   {
     "key": "some key",
-    "value": "some value"
+    "value": "some value",
+    "rate_limit": {
+      "unit": "second",
+      "requests_per_unit": 5
+    }
   }
   |]
 
+-- | Test that parsing a valid leaf descriptor definition passes.
 test_parseJSONDescriptorDefinition :: TestTree
 test_parseJSONDescriptorDefinition =
-  testCase "Successful JSON parsing of DescriptorDefinition" $
+  testCase "Successful JSON parsing of DescriptorDefinitionLeafNode" $
     assertEqual
       "parsing DescriptorDefinition failed"
       (Right expected)
       (parseEither (parseJSON @DescriptorDefinition) descriptor1)
  where
   expected :: DescriptorDefinition
-  expected = DescriptorDefinition
+  expected = DescriptorDefinitionLeafNode
     { descriptorDefinitionKey = RuleKey "some key"
     , descriptorDefinitionValue = Just $ RuleValue "some value"
-    , descriptorDefinitionRateLimit = Nothing
-    , descriptorDefinitionDescriptors = Nothing
+    , descriptorDefinitionRateLimit = RateLimit Second 5
     }
+
+-- | Test that parsing an invalid inner descriptor definition fails.
+test_parseJSONFaultyDescriptorDefinition1 :: TestTree
+test_parseJSONFaultyDescriptorDefinition1 =
+  testCase "Unsuccessful JSON parsing of an inner DescriptorDefinition" $
+    assertEqual
+      "Expected a specific failure, but got something else"
+      (Left expectedErrMsg)
+      (parseEither (parseJSON @DescriptorDefinition) faultyInnerDescriptor)
+ where
+  expectedErrMsg :: String
+  expectedErrMsg =
+    "Error in $: A descriptor with a rate limit cannot have a sub-descriptor"
+
+-- | Test that parsing an invalid leaf descriptor definition fails.
+test_parseJSONFaultyDescriptorDefinition2 :: TestTree
+test_parseJSONFaultyDescriptorDefinition2 =
+  testCase "Unsuccessful JSON parsing of a leaf DescriptorDefinition" $
+    assertEqual
+      "Expected a specific failure, but got something else"
+      (Left expectedErrMsg)
+      (parseEither (parseJSON @DescriptorDefinition) faultyLeafDescriptor)
+ where
+  expectedErrMsg :: String
+  expectedErrMsg =
+    "Error in $: A descriptor definition must have either a rate limit " ++
+    "or sub-descriptor(s)"
 
 descriptor2 :: Value
 descriptor2 = [aesonQQ|
   {
     "key": "some key #2",
     "value": "some value #2",
+    "descriptors": [#{descriptor1}]
+  }
+  |]
+
+-- | An inner descriptor definition cannot have a rate limit so
+-- parsing it should fail.
+faultyInnerDescriptor :: Value
+faultyInnerDescriptor = [aesonQQ|
+  {
+    "key": "some key #2",
+    "value": "some value #2",
     "rate_limit": {
-      "unit": "second",
-      "requests_per_unit": 5
+      "unit": "minute",
+      "requests_per_unit": 11
     },
     "descriptors": [#{descriptor1}]
+  }
+  |]
+
+-- | A leaf descriptor definition must have a rate limit so parsing it
+-- should fail.
+faultyLeafDescriptor :: Value
+faultyLeafDescriptor = [aesonQQ|
+  {
+    "key": "some key #2",
+    "value": "some value #2"
   }
   |]
 
@@ -65,7 +119,7 @@ domain1 :: Value
 domain1 = [aesonQQ|
   {
     "domain": "some domain",
-    "descriptors": [#{descriptor1}, #{descriptor2}]
+    "descriptors": [#{descriptor2}]
   }
   |]
 
@@ -79,21 +133,19 @@ test_parseJSONDomainDefinition =
   expected :: DomainDefinition
   expected = DomainDefinition
     { domainDefinitionId = DomainId "some domain"
-    , domainDefinitionDescriptors = [descriptor1', descriptor2']
+    , domainDefinitionDescriptors = [descriptor2']
     }
   descriptor1' :: DescriptorDefinition
-  descriptor1' = DescriptorDefinition
+  descriptor1' = DescriptorDefinitionLeafNode
     { descriptorDefinitionKey = RuleKey "some key"
     , descriptorDefinitionValue = Just $ RuleValue "some value"
-    , descriptorDefinitionRateLimit = Nothing
-    , descriptorDefinitionDescriptors = Nothing
+    , descriptorDefinitionRateLimit = RateLimit Second 5
     }
   descriptor2' :: DescriptorDefinition
-  descriptor2' = DescriptorDefinition
+  descriptor2' = DescriptorDefinitionInnerNode
     { descriptorDefinitionKey = RuleKey "some key #2"
     , descriptorDefinitionValue = Just $ RuleValue "some value #2"
-    , descriptorDefinitionRateLimit = Just $ RateLimit Second 5
-    , descriptorDefinitionDescriptors = Just [descriptor1']
+    , descriptorDefinitionDescriptors = [descriptor1']
     }
 
 test_parseJSONDomainEmptyDescriptors :: TestTree
@@ -143,20 +195,18 @@ test_parseJSONOptionalDescriptorFields =
     }
     |]
   desc1 :: DescriptorDefinition
-  desc1 = DescriptorDefinition
+  desc1 = DescriptorDefinitionInnerNode
     {
       descriptorDefinitionKey         = RuleKey "key #1"
     , descriptorDefinitionValue       = Just . RuleValue $ "value #1"
-    , descriptorDefinitionRateLimit   = Nothing
-    , descriptorDefinitionDescriptors = Just [
-        DescriptorDefinition
-          {
-            descriptorDefinitionKey         = RuleKey "inner key #1"
-          , descriptorDefinitionValue       = Nothing
-          , descriptorDefinitionRateLimit   = Just RateLimit {rateLimitUnit = Minute, rateLimitRequestsPerUnit = 10}
-          , descriptorDefinitionDescriptors = Nothing
-          }
-        ]
+    , descriptorDefinitionDescriptors =
+      [ DescriptorDefinitionLeafNode
+        {
+          descriptorDefinitionKey       = RuleKey "inner key #1"
+        , descriptorDefinitionValue     = Nothing
+        , descriptorDefinitionRateLimit = RateLimit Minute 10
+        }
+      ]
     }
   desc2Value :: Value
   desc2Value = [aesonQQ|
@@ -166,12 +216,11 @@ test_parseJSONOptionalDescriptorFields =
     }
     |]
   desc2 :: DescriptorDefinition
-  desc2 = DescriptorDefinition
+  desc2 = DescriptorDefinitionLeafNode
     {
       descriptorDefinitionKey         = RuleKey "key #2"
     , descriptorDefinitionValue       = Nothing
-    , descriptorDefinitionRateLimit   = Just RateLimit {rateLimitUnit = Hour, rateLimitRequestsPerUnit = 1000}
-    , descriptorDefinitionDescriptors = Nothing
+    , descriptorDefinitionRateLimit   = RateLimit Hour 1000
     }
   domainValue :: Value
   domainValue = [aesonQQ|


### PR DESCRIPTION
This patch updates the descriptor definition type `DescriptorDefinition` by turning it from a record type with multiple Maybe values into a sum type such that these Maybe values are replaced with proper values in each data constructor. Until now a user was able to provide a configuration that made no sense in the domain.

This change reflects the domain logic that an inner descriptor cannot have a rate limit and that it must have sub-descriptors, and conversely, that a leaf descriptor must have a rate limit and it must have no sub-descriptors. Two new tests are added to the `Fencer.Types.Test` module to confirm the negative cases: `test_parseJSONFaultyDescriptorDefinition1` and `test_parseJSONFaultyDescriptorDefinition2`.

A suggested order of reviewing:

1. `lib/Fencer/Types.hs`
2. `lib/Fencer/Rules.hs`
3. `test/Fencer/Rules/Test/Helpers.hs`
4. `test/Fencer/Types/Test.hs`
5. `test/Fencer/Rules/Test/Examples.hs`
6. `test/Fencer/Logic/Test.hs`

This closes issue #111.
