### PR TITLE
Issue #100: Don't build docs on CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -122,6 +122,10 @@ let
     if static
     then (import nixpkgs { inherit config; }).pkgsMusl
     else import nixpkgs { inherit config; };
+  fencerPre =
+    if pkgs.lib.inNixShell
+    then drv
+    else pkgs.haskell.lib.justStaticExecutables drv;
   drv =
     if static
     then staticPackage pkgs.haskellPackages.fencer
@@ -129,7 +133,7 @@ let
 in {
   pkgs = pkgs;
   fencer =
-    if pkgs.lib.inNixShell
-    then drv
-    else pkgs.haskell.lib.justStaticExecutables drv;
+      if builtins.getEnv "TRAVIS" == "true"
+      then pkgs.haskell.lib.dontHaddock fencerPre
+      else fencerPre;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,7 @@
 let
-  drv = import ./default.nix { withHoogle = true; };
+  drv = import ./default.nix {
+    withHoogle = if builtins.getEnv "TRAVIS" != "" then false else true;
+  };
   pkgs = drv.pkgs;
 in drv.fencer.env.overrideAttrs (attrs: {
   buildInputs = [

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
   drv = import ./default.nix {
-    withHoogle = if builtins.getEnv "TRAVIS" != "" then false else true;
+    withHoogle = if builtins.getEnv "TRAVIS" == "true" then false else true;
   };
   pkgs = drv.pkgs;
 in drv.fencer.env.overrideAttrs (attrs: {


### PR DESCRIPTION
This PR is for issue #100: avoiding building documentation when in the Travis CI.

@srid , obviously what I have so far in the PR (i.e., making `withHoogle` in Nix depend on the TRAVIS environment variable) is not enough because I still get the following when I run `nix-build`:

```
haddockPhase
Preprocessing library for fencer-1.0.0..
Running Haddock on library for fencer-1.0.0..
Warning: --source-* options are ignored when --hyperlinked-source is enabled.
Haddock coverage:
   8% (  1 / 13) in 'Fencer.Proto'
  Missing documentation for:
    RateLimitService (lib/Fencer/Proto.hs:45)
    rateLimitServiceServer (lib/Fencer/Proto.hs:51)
    rateLimitServiceClient (lib/Fencer/Proto.hs:75)
    RateLimitRequest (lib/Fencer/Proto.hs:85)
    RateLimit (lib/Fencer/Proto.hs:191)
    RateLimit_Unit (lib/Fencer/Proto.hs:270)
    RateLimitResponse (lib/Fencer/Proto.hs:328)
    RateLimitResponse_Code (lib/Fencer/Proto.hs:440)
    RateLimitResponse_DescriptorStatus (lib/Fencer/Proto.hs:490)
    HeaderValue (lib/Fencer/Proto.hs:608)
    RateLimitDescriptor (lib/Fencer/Proto.hs:684)
    RateLimitDescriptor_Entry (lib/Fencer/Proto.hs:752)
...
```

What am I missing? I know I should somehow instruct GHC not to run haddock, but I don't know how to do it in Nix.